### PR TITLE
feat(2a): Core database migrations

### DIFF
--- a/migrations/001_create_organizations.down.sql
+++ b/migrations/001_create_organizations.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS organizations;

--- a/migrations/001_create_organizations.up.sql
+++ b/migrations/001_create_organizations.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE organizations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    tier TEXT NOT NULL DEFAULT 'free' CHECK (tier IN ('free', 'paid')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/002_create_agents.down.sql
+++ b/migrations/002_create_agents.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS agents;

--- a/migrations/002_create_agents.up.sql
+++ b/migrations/002_create_agents.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE agents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    slug TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    avatar_url TEXT,
+    webhook_url TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'inactive')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (org_id, slug)
+);

--- a/migrations/003_create_projects.down.sql
+++ b/migrations/003_create_projects.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS projects;

--- a/migrations/003_create_projects.up.sql
+++ b/migrations/003_create_projects.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived', 'completed')),
+    repo_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/004_create_tasks.down.sql
+++ b/migrations/004_create_tasks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tasks;

--- a/migrations/004_create_tasks.up.sql
+++ b/migrations/004_create_tasks.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    project_id UUID REFERENCES projects(id) ON DELETE SET NULL,
+    number SERIAL,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'blocked', 'done')),
+    priority TEXT NOT NULL DEFAULT 'P2' CHECK (priority IN ('P0', 'P1', 'P2', 'P3')),
+    context JSONB DEFAULT '{}',
+    assigned_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    parent_task_id UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX tasks_org_status_priority_idx ON tasks(org_id, status, priority);
+CREATE INDEX tasks_assigned_agent_idx ON tasks(assigned_agent_id);


### PR DESCRIPTION
## Summary
Adds initial database schema migrations for the core entities.

## Changes
- `migrations/001_create_organizations.up.sql` / `down.sql`
- `migrations/002_create_agents.up.sql` / `down.sql`
- `migrations/003_create_projects.up.sql` / `down.sql`
- `migrations/004_create_tasks.up.sql` / `down.sql`

## Entities
- **Organizations** - Top-level tenant
- **Agents** - AI agents with session keys
- **Projects** - Work containers
- **Tasks** - Tracked items within projects

## Codex Agent: quick-comet
Built by Codex sub-agent in overnight build sprint.