### PR TITLE
fix(2a): Schema fixes - status enum, session_pattern, per-org task numbers

### DIFF
--- a/migrations/005_fix_schema.down.sql
+++ b/migrations/005_fix_schema.down.sql
@@ -1,0 +1,19 @@
+-- Rollback schema fixes (Issue #19)
+
+-- Remove per-org task number constraint and trigger
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_org_number_unique;
+DROP TRIGGER IF EXISTS set_task_number ON tasks;
+DROP FUNCTION IF EXISTS next_task_number();
+
+-- Restore SERIAL behavior
+CREATE SEQUENCE IF NOT EXISTS tasks_number_seq;
+ALTER TABLE tasks ALTER COLUMN number SET DEFAULT nextval('tasks_number_seq');
+
+-- Remove session_pattern from agents
+ALTER TABLE agents DROP COLUMN IF EXISTS session_pattern;
+
+-- Restore original status enum
+ALTER TABLE tasks DROP CONSTRAINT tasks_status_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_status_check 
+  CHECK (status IN ('open', 'in_progress', 'blocked', 'done'));
+UPDATE tasks SET status = 'open' WHERE status = 'queued';

--- a/migrations/005_fix_schema.up.sql
+++ b/migrations/005_fix_schema.up.sql
@@ -1,0 +1,35 @@
+-- Fix schema issues from PR #17 review (Issue #19)
+
+-- 1. Fix task status enum to match spec
+ALTER TABLE tasks DROP CONSTRAINT tasks_status_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_status_check 
+  CHECK (status IN ('queued', 'dispatched', 'in_progress', 'blocked', 'review', 'done', 'cancelled'));
+UPDATE tasks SET status = 'queued' WHERE status = 'open';
+
+-- 2. Add session_pattern to agents for OpenClaw routing
+ALTER TABLE agents ADD COLUMN session_pattern TEXT;
+
+-- 3. Fix task number to be per-org unique (not global SERIAL)
+-- Drop the SERIAL default
+ALTER TABLE tasks ALTER COLUMN number DROP DEFAULT;
+
+-- Drop the auto-created sequence if it exists
+DROP SEQUENCE IF EXISTS tasks_number_seq;
+
+-- Create function for per-org task numbering
+CREATE OR REPLACE FUNCTION next_task_number() RETURNS TRIGGER AS $$
+BEGIN
+  SELECT COALESCE(MAX(number), 0) + 1 INTO NEW.number 
+  FROM tasks WHERE org_id = NEW.org_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to auto-assign number on insert
+CREATE TRIGGER set_task_number 
+  BEFORE INSERT ON tasks
+  FOR EACH ROW 
+  EXECUTE FUNCTION next_task_number();
+
+-- Add unique constraint for org + number
+ALTER TABLE tasks ADD CONSTRAINT tasks_org_number_unique UNIQUE (org_id, number);


### PR DESCRIPTION
## Summary
Fixes #19 — schema issues found in PR #17 post-merge review.

## Changes

### 1. Task status enum
**Before:** `open, in_progress, blocked, done`
**After:** `queued, dispatched, in_progress, blocked, review, done, cancelled`

### 2. Agents session_pattern
Added `session_pattern TEXT` column for OpenClaw routing (e.g., `agent:2b:*`).

### 3. Per-org task numbers
- Removed global SERIAL
- Added trigger-based per-org numbering
- Added `UNIQUE(org_id, number)` constraint

## Testing
```bash
make up                    # Start postgres
go run ./cmd/migrate up    # Apply migrations
go run ./cmd/migrate down 1 && go run ./cmd/migrate up  # Test rollback
```

## Checklist
- [x] Migration applies cleanly
- [x] Rollback migration included
- [x] Status enum matches spec
- [x] session_pattern column added
- [x] Task numbers per-org unique

---
*Derek (Engineering Lead)*