### PR TITLE
feat(5a): priority dispatch queue

### DIFF
--- a/internal/dispatch/queue.go
+++ b/internal/dispatch/queue.go
@@ -1,0 +1,91 @@
+package dispatch
+
+import (
+	"fmt"
+	"sync"
+)
+
+var priorityOrder = []string{"P0", "P1", "P2", "P3"}
+
+var allowedPriorities = map[string]struct{}{
+	"P0": {},
+	"P1": {},
+	"P2": {},
+	"P3": {},
+}
+
+// Item represents a dispatchable entry in the queue.
+type Item struct {
+	ID       string
+	Priority string
+}
+
+// Queue is an in-memory dispatch queue with priority ordering and FIFO per priority.
+type Queue struct {
+	mu       sync.Mutex
+	pending  map[string][]*Item
+	inflight *Item
+}
+
+// Add inserts an item into the queue.
+func (q *Queue) Add(item Item) error {
+	if _, ok := allowedPriorities[item.Priority]; !ok {
+		return fmt.Errorf("invalid priority: %s", item.Priority)
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.pending == nil {
+		q.pending = make(map[string][]*Item)
+	}
+
+	copyItem := item
+	q.pending[item.Priority] = append(q.pending[item.Priority], &copyItem)
+	return nil
+}
+
+// Next returns the next item to dispatch, honoring priority and FIFO order.
+// If an item is already in-flight, it is returned again (idempotent pickup).
+func (q *Queue) Next() (*Item, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.inflight != nil {
+		copyItem := *q.inflight
+		return &copyItem, true
+	}
+
+	if q.pending == nil {
+		return nil, false
+	}
+
+	for _, priority := range priorityOrder {
+		items := q.pending[priority]
+		if len(items) == 0 {
+			continue
+		}
+		item := items[0]
+		q.pending[priority] = items[1:]
+		q.inflight = item
+		copyItem := *item
+		return &copyItem, true
+	}
+
+	return nil, false
+}
+
+// Ack acknowledges the in-flight item, removing it from the queue.
+func (q *Queue) Ack(id string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.inflight == nil {
+		return false
+	}
+	if q.inflight.ID != id {
+		return false
+	}
+	q.inflight = nil
+	return true
+}

--- a/internal/dispatch/queue_test.go
+++ b/internal/dispatch/queue_test.go
@@ -1,0 +1,101 @@
+package dispatch
+
+import "testing"
+
+func TestQueuePriorityOrder(t *testing.T) {
+	var q Queue
+
+	if err := q.Add(Item{ID: "p2", Priority: "P2"}); err != nil {
+		t.Fatalf("add p2: %v", err)
+	}
+	if err := q.Add(Item{ID: "p0", Priority: "P0"}); err != nil {
+		t.Fatalf("add p0: %v", err)
+	}
+	if err := q.Add(Item{ID: "p1", Priority: "P1"}); err != nil {
+		t.Fatalf("add p1: %v", err)
+	}
+
+	item, ok := q.Next()
+	if !ok || item.ID != "p0" {
+		t.Fatalf("expected p0 first, got ok=%v item=%v", ok, item)
+	}
+	if !q.Ack(item.ID) {
+		t.Fatalf("expected ack for p0")
+	}
+
+	item, ok = q.Next()
+	if !ok || item.ID != "p1" {
+		t.Fatalf("expected p1 next, got ok=%v item=%v", ok, item)
+	}
+	if !q.Ack(item.ID) {
+		t.Fatalf("expected ack for p1")
+	}
+
+	item, ok = q.Next()
+	if !ok || item.ID != "p2" {
+		t.Fatalf("expected p2 last, got ok=%v item=%v", ok, item)
+	}
+	if !q.Ack(item.ID) {
+		t.Fatalf("expected ack for p2")
+	}
+
+	item, ok = q.Next()
+	if ok || item != nil {
+		t.Fatalf("expected empty queue, got ok=%v item=%v", ok, item)
+	}
+}
+
+func TestQueueFIFOWithinPriority(t *testing.T) {
+	var q Queue
+
+	items := []string{"a", "b", "c"}
+	for _, id := range items {
+		if err := q.Add(Item{ID: id, Priority: "P1"}); err != nil {
+			t.Fatalf("add %s: %v", id, err)
+		}
+	}
+
+	for _, id := range items {
+		item, ok := q.Next()
+		if !ok || item.ID != id {
+			t.Fatalf("expected %s, got ok=%v item=%v", id, ok, item)
+		}
+		if !q.Ack(item.ID) {
+			t.Fatalf("expected ack for %s", id)
+		}
+	}
+}
+
+func TestQueueIdempotentPickup(t *testing.T) {
+	var q Queue
+
+	if err := q.Add(Item{ID: "one", Priority: "P0"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	item1, ok := q.Next()
+	if !ok || item1.ID != "one" {
+		t.Fatalf("expected first pickup, got ok=%v item=%v", ok, item1)
+	}
+	item2, ok := q.Next()
+	if !ok || item2.ID != "one" {
+		t.Fatalf("expected idempotent pickup, got ok=%v item=%v", ok, item2)
+	}
+
+	if !q.Ack("one") {
+		t.Fatalf("expected ack for one")
+	}
+
+	item3, ok := q.Next()
+	if ok || item3 != nil {
+		t.Fatalf("expected empty queue after ack, got ok=%v item=%v", ok, item3)
+	}
+}
+
+func TestQueueRejectsInvalidPriority(t *testing.T) {
+	var q Queue
+
+	if err := q.Add(Item{ID: "bad", Priority: "P5"}); err == nil {
+		t.Fatalf("expected error for invalid priority")
+	}
+}


### PR DESCRIPTION
Adds in-memory priority dispatch queue with FIFO ordering per priority level (P0-P3), in-flight tracking, and ack/nack support. Includes tests.