### PR TITLE
feat: CLI auth + config layer (#220)

### DIFF
--- a/cmd/otter/main.go
+++ b/cmd/otter/main.go
@@ -132,7 +132,6 @@ func handleProject(args []string) {
 	switch args[0] {
 	case "create":
 		flags := flag.NewFlagSet("project create", flag.ExitOnError)
-		flags.SetInterspersed(true)
 		description := flags.String("description", "", "project description")
 		status := flags.String("status", "", "status (active|archived|completed)")
 		repoURL := flags.String("repo-url", "", "repo URL")


### PR DESCRIPTION
Implements issue #220: Otter CLI authentication and configuration layer.

## What's included
- **Config layer**: `~/.config/otter/config.json` with `apiBaseUrl`, `token`, `defaultOrg`
- **`otter auth login --token`**: Store API token + default org
- **`otter whoami`**: Validate token, show user info
- **`--org` override**: Per-command org override
- **`--json` output**: Machine-readable JSON output for `whoami`, `project create`, `clone`, `repo info`
- **Makefile target**: `make build-otter`
- **Config test**: Unit test for save/load round-trip

## Files changed
- `cmd/otter/main.go` — CLI entry point with subcommands
- `internal/ottercli/config.go` — Config load/save
- `internal/ottercli/config_test.go` — Config tests  
- `internal/ottercli/client.go` — API client with auth headers
- `Makefile` — `build-otter` target