### PR TITLE
feat(nav): #3 Nav cleanup, avatar dropdown, chat fullscreen

### DIFF
--- a/web/src/components/chat/GlobalChatDock.tsx
+++ b/web/src/components/chat/GlobalChatDock.tsx
@@ -30,6 +30,7 @@ export default function GlobalChatDock() {
   const [refreshVersion, setRefreshVersion] = useState(0);
   const [resettingProjectSession, setResettingProjectSession] = useState(false);
   const [resetProjectError, setResetProjectError] = useState<string | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const visibleConversations = useMemo(() => {
     if (conversations.length > 0) {
@@ -50,12 +51,16 @@ export default function GlobalChatDock() {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && isOpen) {
-        setDockOpen(false);
+        if (isFullscreen) {
+          setIsFullscreen(false);
+        } else {
+          setDockOpen(false);
+        }
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, setDockOpen]);
+  }, [isOpen, isFullscreen, setDockOpen]);
 
   useEffect(() => {
     setResetProjectError(null);
@@ -196,8 +201,11 @@ export default function GlobalChatDock() {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 w-[min(960px,calc(100vw-2rem))]">
-      <section className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-2xl">
+    <div className={isFullscreen
+      ? "fixed inset-0 top-[var(--topbar-height,56px)] z-50"
+      : "fixed bottom-4 right-4 z-50 w-[min(960px,calc(100vw-2rem))]"
+    }>
+      <section className={`overflow-hidden border border-[var(--border)] bg-[var(--surface)] shadow-2xl ${isFullscreen ? "h-full" : "rounded-2xl"}`}>
         <header className="flex items-center justify-between border-b border-[var(--border)] bg-[var(--surface-alt)] px-4 py-2.5">
           <div className="flex items-center gap-3">
             <h2 className="text-sm font-semibold text-[var(--text)]">Global Chat</h2>
@@ -216,7 +224,15 @@ export default function GlobalChatDock() {
             </button>
             <button
               type="button"
-              onClick={toggleDock}
+              onClick={() => setIsFullscreen(!isFullscreen)}
+              className="rounded-lg border border-[var(--border)] px-2.5 py-1 text-xs text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+              aria-label={isFullscreen ? "Exit fullscreen chat" : "Fullscreen chat"}
+            >
+              {isFullscreen ? "⊡" : "⊞"}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setIsFullscreen(false); toggleDock(); }}
               className="rounded-lg border border-[var(--border)] px-2.5 py-1 text-xs text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
               aria-label="Collapse global chat"
             >
@@ -224,7 +240,7 @@ export default function GlobalChatDock() {
             </button>
             <button
               type="button"
-              onClick={() => setDockOpen(false)}
+              onClick={() => { setIsFullscreen(false); setDockOpen(false); }}
               className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
               aria-label="Close global chat"
             >
@@ -238,7 +254,7 @@ export default function GlobalChatDock() {
           </div>
         ) : null}
 
-        <div className="grid h-[min(72vh,620px)] max-h-[calc(100vh-2rem)] grid-cols-[260px_1fr]">
+        <div className={`grid grid-cols-[260px_1fr] ${isFullscreen ? "h-[calc(100%-44px)]" : "h-[min(72vh,620px)] max-h-[calc(100vh-2rem)]"}`}>
           <aside className="min-h-0 border-r border-[var(--border)] bg-[var(--surface-alt)]/50">
             <div className="h-full overflow-y-auto p-2">
               {visibleConversations.length === 0 ? (

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -585,6 +585,77 @@ textarea::placeholder {
   background: rgba(255, 255, 255, 0.3);
 }
 
+/* Avatar Dropdown Menu */
+.avatar-menu-container {
+  position: relative;
+}
+
+.avatar-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 180px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  padding: 4px;
+  z-index: 100;
+  animation: avatar-dropdown-in 0.15s ease-out;
+}
+
+@keyframes avatar-dropdown-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.avatar-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+
+.avatar-dropdown-item:hover {
+  background: var(--surface-alt);
+}
+
+.avatar-dropdown-item.active {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.avatar-dropdown-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.avatar-dropdown-logout {
+  color: var(--red, #e53e3e);
+}
+
+.avatar-dropdown-logout:hover {
+  background: rgba(229, 62, 62, 0.1);
+}
+
+/* Mobile logout button */
+.mobile-logout {
+  color: var(--red, #e53e3e) !important;
+  border: none;
+  background: none;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
 /* ========================================
    CONNECTION STATUS
    ======================================== */


### PR DESCRIPTION
Implements Issue #3:

- Remove Dashboard from primary nav (logo already links to /)
- Primary nav: Inbox | Projects | Workflows | Knowledge
- Avatar dropdown: Agents, Connections, Feed, Settings, Log Out
- Dropdown closes on outside click / Escape
- Mobile nav shows all items + Log Out
- Chat fullscreen toggle (⊞/⊡) in GlobalChatDock header
- Escape exits fullscreen before closing dock

Typechecks clean.