### PR TITLE
spec-121: onboarding required OpenClaw agents (r2 clean base)

### DIFF
--- a/cmd/otter/init.go
+++ b/cmd/otter/init.go
@@ -44,11 +44,12 @@ var (
 	detectInitOpenClaw = func() (*importer.OpenClawInstallation, error) {
 		return importer.DetectOpenClawInstallation(importer.DetectOpenClawOptions{})
 	}
-	importInitOpenClawIdentities = importer.ImportOpenClawAgentIdentities
-	inferInitOpenClawProjects    = importer.InferOpenClawProjectCandidates
-	resolveInitRepoRoot          = gitRepoRoot
-	writeInitBridgeEnv           = writeBridgeEnvFile
-	startInitBridge              = startBridgeProcess
+	ensureInitOpenClawRequiredAgents = importer.EnsureOpenClawRequiredAgents
+	importInitOpenClawIdentities     = importer.ImportOpenClawAgentIdentities
+	inferInitOpenClawProjects        = importer.InferOpenClawProjectCandidates
+	resolveInitRepoRoot              = gitRepoRoot
+	writeInitBridgeEnv               = writeBridgeEnvFile
+	startInitBridge                  = startBridgeProcess
 )
 
 const (
@@ -249,6 +250,22 @@ func runInitImportAndBridge(reader *bufio.Reader, out io.Writer, client initBoot
 	}
 
 	fmt.Fprintf(out, "Found OpenClaw at %s with %d agent workspaces.\n", installation.RootDir, len(installation.Agents))
+	ensureResult, ensureErr := ensureInitOpenClawRequiredAgents(installation, importer.EnsureOpenClawRequiredAgentsOptions{
+		IncludeChameleon: true,
+	})
+	switch {
+	case ensureErr != nil:
+		fmt.Fprintf(out, "WARNING: OpenClaw config update failed: %v\n", ensureErr)
+	case ensureResult.Updated:
+		if ensureResult.AddedMemoryAgent {
+			fmt.Fprintln(out, "Added Memory Agent to OpenClaw config. Restart OpenClaw when ready to activate.")
+		}
+		if ensureResult.AddedChameleon {
+			fmt.Fprintln(out, "Added Chameleon to OpenClaw config. Restart OpenClaw when ready to activate.")
+		}
+	default:
+		fmt.Fprintln(out, "Required OpenClaw agents already present. No config changes made.")
+	}
 
 	if promptYesNo(reader, out, "Import agents and projects from OpenClaw? (Y/n): ", true) {
 		agentsImported, projectsImported, issuesImported := importOpenClawData(out, client, installation)

--- a/internal/import/openclaw.go
+++ b/internal/import/openclaw.go
@@ -1,8 +1,10 @@
 package importer
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -51,6 +53,17 @@ type ImportedAgentIdentity struct {
 	SourceFiles  map[string]string
 }
 
+type EnsureOpenClawRequiredAgentsOptions struct {
+	IncludeChameleon bool
+}
+
+type EnsureOpenClawRequiredAgentsResult struct {
+	Updated            bool
+	AddedMemoryAgent   bool
+	AddedChameleon     bool
+	MemoryWorkspaceDir string
+}
+
 type openClawConfigFile struct {
 	Gateway        map[string]any  `json:"gateway"`
 	SessionsDir    string          `json:"sessions_dir"`
@@ -65,6 +78,261 @@ type openClawAgentCandidate struct {
 	ID        string
 	Name      string
 	Workspace string
+}
+
+var memoryAgentSOULTemplate = strings.TrimSpace(`# Memory Agent
+
+You are the Memory Agent. Your job is to read agent session logs, extract what's worth
+remembering, and distribute it via Otter Camp memory and knowledge commands.
+
+You run quietly and prioritize signal over noise.
+`)
+
+var memoryAgentStateTemplate = map[string]any{
+	"file_offsets": map[string]any{},
+	"last_run":     nil,
+	"extraction_stats": map[string]any{
+		"total_runs":             0,
+		"total_memories_written": 0,
+		"total_knowledge_shared": 0,
+		"last_run_duration_ms":   0,
+	},
+}
+
+func EnsureOpenClawRequiredAgents(
+	install *OpenClawInstallation,
+	opts EnsureOpenClawRequiredAgentsOptions,
+) (EnsureOpenClawRequiredAgentsResult, error) {
+	if install == nil {
+		return EnsureOpenClawRequiredAgentsResult{}, errors.New("installation is required")
+	}
+	configPath := strings.TrimSpace(install.ConfigPath)
+	if configPath == "" || !isFile(configPath) {
+		return EnsureOpenClawRequiredAgentsResult{}, nil
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return EnsureOpenClawRequiredAgentsResult{}, err
+	}
+	root := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := json.Unmarshal(raw, &root); err != nil {
+			return EnsureOpenClawRequiredAgentsResult{}, err
+		}
+	}
+
+	result := EnsureOpenClawRequiredAgentsResult{}
+	switch agents := root["agents"].(type) {
+	case map[string]any:
+		if list, ok := agents["list"].([]any); ok {
+			updatedList, addedMemory, addedChameleon := ensureListAgentSlots(list, opts)
+			agents["list"] = updatedList
+			result.AddedMemoryAgent = addedMemory
+			result.AddedChameleon = addedChameleon
+			result.Updated = addedMemory || addedChameleon
+		} else {
+			addedMemory := ensureMapAgentSlot(agents, "memory-agent", buildMemoryAgentSlot())
+			addedChameleon := false
+			if opts.IncludeChameleon {
+				addedChameleon = ensureMapAgentSlot(agents, "chameleon", buildChameleonSlot())
+			}
+			result.AddedMemoryAgent = addedMemory
+			result.AddedChameleon = addedChameleon
+			result.Updated = addedMemory || addedChameleon
+		}
+		root["agents"] = agents
+	case []any:
+		updated, addedMemory, addedChameleon := ensureListAgentSlots(agents, opts)
+		result.Updated = addedMemory || addedChameleon
+		result.AddedMemoryAgent = addedMemory
+		result.AddedChameleon = addedChameleon
+		root["agents"] = updated
+	default:
+		agentsObj := map[string]any{
+			"list": []any{},
+		}
+		updated, addedMemory, addedChameleon := ensureListAgentSlots(agentsObj["list"].([]any), opts)
+		agentsObj["list"] = updated
+		root["agents"] = agentsObj
+		result.Updated = addedMemory || addedChameleon
+		result.AddedMemoryAgent = addedMemory
+		result.AddedChameleon = addedChameleon
+	}
+
+	if result.AddedMemoryAgent {
+		workspaceDir, err := ensureMemoryAgentWorkspace(install.RootDir)
+		if err != nil {
+			return EnsureOpenClawRequiredAgentsResult{}, err
+		}
+		result.MemoryWorkspaceDir = workspaceDir
+	}
+
+	if !result.Updated {
+		return result, nil
+	}
+
+	encoded, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return EnsureOpenClawRequiredAgentsResult{}, err
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(configPath, encoded, 0o644); err != nil {
+		return EnsureOpenClawRequiredAgentsResult{}, err
+	}
+	return result, nil
+}
+
+func ensureListAgentSlots(
+	agents []any,
+	opts EnsureOpenClawRequiredAgentsOptions,
+) (updated []any, addedMemory bool, addedChameleon bool) {
+	updated = append([]any{}, agents...)
+	if !listHasAgentID(updated, "memory-agent") {
+		updated = append(updated, buildMemoryAgentSlot())
+		addedMemory = true
+	}
+	if opts.IncludeChameleon && !listHasAgentID(updated, "chameleon") {
+		updated = append(updated, buildChameleonSlot())
+		addedChameleon = true
+	}
+	return updated, addedMemory, addedChameleon
+}
+
+func listHasAgentID(agents []any, id string) bool {
+	target := strings.TrimSpace(strings.ToLower(id))
+	if target == "" {
+		return false
+	}
+	for _, item := range agents {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		candidate := strings.ToLower(strings.TrimSpace(lookupString(record, "id", "slug", "agent_id", "agent")))
+		if candidate == target {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureMapAgentSlot(agents map[string]any, id string, value map[string]any) bool {
+	target := strings.TrimSpace(strings.ToLower(id))
+	if target == "" {
+		return false
+	}
+	for key, existing := range agents {
+		if strings.EqualFold(strings.TrimSpace(key), target) {
+			return false
+		}
+		record, ok := existing.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(lookupString(record, "id", "slug", "agent_id", "agent")), target) {
+			return false
+		}
+	}
+	agents[id] = value
+	return true
+}
+
+func buildMemoryAgentSlot() map[string]any {
+	return map[string]any{
+		"id":        "memory-agent",
+		"name":      "Memory Agent",
+		"model":     "anthropic/claude-sonnet-4-20250514",
+		"workspace": "~/.openclaw/workspace-memory-agent",
+		"thinking":  "low",
+		"channels":  []any{},
+	}
+}
+
+func buildChameleonSlot() map[string]any {
+	return map[string]any{
+		"id":        "chameleon",
+		"name":      "Chameleon",
+		"workspace": "~/.openclaw/workspace-chameleon",
+	}
+}
+
+func ensureMemoryAgentWorkspace(rootDir string) (string, error) {
+	base := strings.TrimSpace(rootDir)
+	if base == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, ".openclaw")
+		}
+	}
+	if base == "" {
+		return "", errors.New("openclaw root dir is required for memory workspace setup")
+	}
+	workspaceDir := filepath.Join(base, "workspace-memory-agent")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(workspaceDir)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("workspace path is not a real directory: %s", workspaceDir)
+	}
+
+	if err := writeFileIfMissing(filepath.Join(workspaceDir, "SOUL.md"), []byte(memoryAgentSOULTemplate+"\n"), 0o644); err != nil {
+		return "", err
+	}
+
+	stateRaw, err := json.MarshalIndent(memoryAgentStateTemplate, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	stateRaw = append(stateRaw, '\n')
+	if err := writeFileIfMissing(filepath.Join(workspaceDir, "memory-agent-state.json"), stateRaw, 0o644); err != nil {
+		return "", err
+	}
+
+	return workspaceDir, nil
+}
+
+func writeFileIfMissing(path string, content []byte, mode fs.FileMode) error {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink: %s", path)
+		}
+		if info.Mode().IsRegular() {
+			return nil
+		}
+		return fmt.Errorf("path already exists and is not a regular file: %s", path)
+	case !errors.Is(err, fs.ErrNotExist):
+		return err
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		if !errors.Is(err, fs.ErrExist) {
+			return err
+		}
+		existing, statErr := os.Lstat(path)
+		if statErr != nil {
+			return err
+		}
+		if existing.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink: %s", path)
+		}
+		if existing.Mode().IsRegular() {
+			return nil
+		}
+		return fmt.Errorf("path already exists and is not a regular file: %s", path)
+	}
+	defer file.Close()
+
+	if _, err := file.Write(content); err != nil {
+		return err
+	}
+	return nil
 }
 
 func DetectOpenClawInstallation(opts DetectOpenClawOptions) (*OpenClawInstallation, error) {


### PR DESCRIPTION
## Summary
- rebuild spec-121 changes on top of current `main` without stale spec-120 history
- keep diff strictly limited to the 4 onboarding files required by reviewer P0
- preserve prior hardening behavior and tests from #665/#666

## Validation
- `git diff --stat origin/main...HEAD` (4 files only)
- `go vet ./...`
- `go build ./...`
- `go test ./...`

## Notes
- This PR replaces #692 for reviewer P0 stale-base resolution because force-pushing #692 head branch was blocked in the execution environment.
- Addresses #664