### PR TITLE
Spec 128: onboarding P1 login local/hosted UX

### DIFF
--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -48,6 +48,17 @@ describe("LoginPage", () => {
     expect(screen.queryByLabelText(/email address/i)).not.toBeInTheDocument();
   });
 
+  it("shows decision-aligned copy for local and hosted paths", async () => {
+    const user = userEvent.setup();
+    render(<LoginPage />);
+
+    expect(screen.getByText(/local setup is available now via magic link/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /hosted setup/i }));
+
+    expect(screen.getByText(/hosted setup is deferred for now/i)).toBeInTheDocument();
+  });
+
   it("submits local mode via login", async () => {
     const user = userEvent.setup();
     let resolveLogin: (() => void) | null = null;

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -72,64 +72,67 @@ export default function LoginPage() {
               )}
 
               {setupMode === "local" ? (
-                <form onSubmit={handleSubmit}>
-                  <div className="form-group">
-                    <label htmlFor="name" className="form-label">
-                      Name
-                    </label>
-                    <input
-                      id="name"
-                      type="text"
-                      className="form-input"
-                      placeholder="Your name"
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      autoComplete="name"
-                      autoFocus
-                    />
-                  </div>
+                <>
+                  <p className="mode-copy">Local setup is available now via magic link.</p>
+                  <form onSubmit={handleSubmit}>
+                    <div className="form-group">
+                      <label htmlFor="name" className="form-label">
+                        Name
+                      </label>
+                      <input
+                        id="name"
+                        type="text"
+                        className="form-input"
+                        placeholder="Your name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        autoComplete="name"
+                        autoFocus
+                      />
+                    </div>
 
-                  <div className="form-group">
-                    <label htmlFor="org" className="form-label">
-                      Organization
-                    </label>
-                    <input
-                      id="org"
-                      type="text"
-                      className="form-input"
-                      placeholder="Your org name"
-                      value={org}
-                      onChange={(e) => setOrg(e.target.value)}
-                    />
-                  </div>
+                    <div className="form-group">
+                      <label htmlFor="org" className="form-label">
+                        Organization
+                      </label>
+                      <input
+                        id="org"
+                        type="text"
+                        className="form-input"
+                        placeholder="Your org name"
+                        value={org}
+                        onChange={(e) => setOrg(e.target.value)}
+                      />
+                    </div>
 
-                  <div className="form-group">
-                    <label htmlFor="email" className="form-label">
-                      Email address
-                    </label>
-                    <input
-                      id="email"
-                      type="email"
-                      className="form-input"
-                      placeholder="you@example.com"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      required
-                      autoComplete="email"
-                    />
-                    <p className="form-hint">
-                      We'll generate a magic link to sign in
-                    </p>
-                  </div>
+                    <div className="form-group">
+                      <label htmlFor="email" className="form-label">
+                        Email address
+                      </label>
+                      <input
+                        id="email"
+                        type="email"
+                        className="form-input"
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        autoComplete="email"
+                      />
+                      <p className="form-hint">
+                        We'll generate a magic link to sign in
+                      </p>
+                    </div>
 
-                  <button
-                    type="submit"
-                    className="btn btn-primary"
-                    disabled={isSubmitting}
-                  >
-                    {isSubmitting ? "Sending..." : "Generate Magic Link"}
-                  </button>
-                </form>
+                    <button
+                      type="submit"
+                      className="btn btn-primary"
+                      disabled={isSubmitting}
+                    >
+                      {isSubmitting ? "Sending..." : "Generate Magic Link"}
+                    </button>
+                  </form>
+                </>
               ) : (
                 <div className="hosted-panel">
                   <h3 className="hosted-title">Hosted onboarding is moving to otter.camp/setup</h3>
@@ -264,6 +267,12 @@ export default function LoginPage() {
           border-color: var(--accent, #C9A86C);
           background: rgba(201, 168, 108, 0.18);
           color: var(--text, #FAF8F5);
+        }
+
+        .mode-copy {
+          color: var(--text-muted, #A69582);
+          font-size: 14px;
+          margin: 0 0 16px;
         }
 
         .form-group {


### PR DESCRIPTION
## Summary
- add a Local/Hosted setup selector to `LoginPage` with Local default
- show Hosted deferment guidance and setup link to `https://otter.camp/setup`
- preserve local magic-link submit/success/error behavior under mode switching
- add/expand `LoginPage` regression tests for mode rendering, submit behavior, and decision-aligned copy

## Linked Work
- closes #757
- closes #758
- closes #759
- refs #239

## Tests
- `cd web && npx vitest run src/pages/LoginPage.test.tsx -t "defaults to local onboarding mode"`
- `cd web && npx vitest run src/pages/LoginPage.test.tsx -t "shows hosted setup guidance when hosted mode is selected"`
- `cd web && npx vitest run src/pages/LoginPage.test.tsx -t "submits local mode via login"`
- `cd web && npx vitest run src/pages/LoginPage.test.tsx -t "shows magic-link success state after local submit"`
- `cd web && npx vitest run src/pages/LoginPage.test.tsx -t "shows API error when local submit fails"`
- `cd web && npx vitest run src/pages/LoginPage.test.tsx`
- `cd web && npx vitest run src/components/AuthHandler.test.tsx src/contexts/__tests__/AuthContext.test.tsx`
