### PR TITLE
fix(import): enforce source-guard symlink escape checks

### DIFF
--- a/internal/import/openclaw_source_guard.go
+++ b/internal/import/openclaw_source_guard.go
@@ -56,16 +56,10 @@ func (g *OpenClawSourceGuard) ValidateReadPath(path string) error {
 		target = filepath.Clean(filepath.Join(g.rootDir, target))
 	}
 
-	// Check the logical path (before symlink resolution) is within root.
-	// This allows reading identity files that are symlinked outside the root
-	// (e.g., SOUL.md -> ~/Documents/SamsBrain/Agents/Frank/SOUL.md).
-	// The symlink itself must live within the OpenClaw directory.
-	if isWithinDir(g.rootDir, target) {
-		return nil
-	}
-
-	// If the logical path isn't within root, try resolving symlinks
-	// and check again (handles case where root itself is a symlink).
+	// Resolve symlinks (or missing final path segments) and enforce root
+	// containment on the resolved path. This handles platform path aliases
+	// (e.g. /var -> /private/var on macOS) while still rejecting symlink
+	// escapes that resolve outside the OpenClaw root.
 	resolvedTarget, err := resolveOpenClawGuardPath(target)
 	if err != nil {
 		return fmt.Errorf("resolve path %s: %w", target, err)

--- a/internal/import/openclaw_source_guard_test.go
+++ b/internal/import/openclaw_source_guard_test.go
@@ -28,3 +28,22 @@ func TestOpenClawSourceGuardRejectsSymlinkEscape(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "outside openclaw root")
 }
+
+func TestOpenClawSourceGuardAllowsSymlinkInsideRoot(t *testing.T) {
+	root := t.TempDir()
+
+	sessionDir := filepath.Join(root, "agents", "main", "sessions")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	insideFile := filepath.Join(root, "allowed.jsonl")
+	require.NoError(t, os.WriteFile(insideFile, []byte("safe\n"), 0o644))
+
+	insideLink := filepath.Join(sessionDir, "inside.jsonl")
+	require.NoError(t, os.Symlink(insideFile, insideLink))
+
+	guard, err := NewOpenClawSourceGuard(root)
+	require.NoError(t, err)
+
+	err = guard.ValidateReadPath(insideLink)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- fix Linux/macOS divergence in OpenClaw source guard path validation by enforcing containment on symlink-resolved paths
- keep valid in-root symlink reads allowed
- add regression coverage for in-root symlink allow-path

## Validation
- go test -v -race ./internal/import -run TestOpenClawSourceGuardRejectsSymlinkEscape -count=1
- go test ./internal/import -run 'TestOpenClawSourceGuardRejectsSymlinkEscape|TestOpenClawSourceGuardAllowsSymlinkInsideRoot|TestOpenClawSessionParserRejectsSymlinkedSessionFile|TestOpenClawMigrationRejectsUnsafeWriteOperations' -count=1
- go vet ./...
- go build ./...
- go test ./... -count=1

Refs: #939