### PR TITLE
spec-304: project docs ingestion

### DIFF
--- a/docs/START-HERE.md
+++ b/docs/START-HERE.md
@@ -146,6 +146,7 @@ Primary implementation wave came through issue/commit streams around Spec #150-#
 
 ## Change Log
 
+- 2026-02-16: Added project-docs ingestion architecture updates for scanner, retrieval, and migration runner phases (Spec 304).
 - 2026-02-16: Bug fix in CI test guardrails; no behavior change.
 - 2026-02-16: Added explicit navigation instructions, mandatory docs maintenance policy, and CI docs-guard enforcement guidance.
 - 2026-02-16: Added docs/instructions/ directory (working WITH vs ON distinction) and updated navigation.

--- a/internal/import/openclaw_migration_report.go
+++ b/internal/import/openclaw_migration_report.go
@@ -9,6 +9,7 @@ type OpenClawMigrationSummaryReport struct {
 	MemoryDedupProcessed            int
 	TaxonomyClassificationProcessed int
 	ProjectDiscoveryProcessed       int
+	ProjectDocsScanningProcessed    int
 	FailedItems                     int
 	Warnings                        []string
 }
@@ -37,6 +38,9 @@ func BuildOpenClawMigrationSummaryReport(result RunOpenClawMigrationResult) Open
 	}
 	if result.ProjectDiscovery != nil {
 		report.ProjectDiscoveryProcessed = result.ProjectDiscovery.ProcessedItems
+	}
+	if result.ProjectDocsScanning != nil {
+		report.ProjectDocsScanningProcessed = result.ProjectDocsScanning.ProcessedDocs
 	}
 	if result.Paused {
 		report.Warnings = append(report.Warnings, "migration paused before all phases completed")

--- a/internal/memory/ellie_project_docs_scanner.go
+++ b/internal/memory/ellie_project_docs_scanner.go
@@ -1,0 +1,544 @@
+package memory
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var markdownLinkPattern = regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+
+const defaultProjectDocSectionMaxChars = 4000
+
+type EllieProjectDocChangeStatus string
+
+const (
+	EllieProjectDocChangeStatusNew       EllieProjectDocChangeStatus = "new"
+	EllieProjectDocChangeStatusChanged   EllieProjectDocChangeStatus = "changed"
+	EllieProjectDocChangeStatusUnchanged EllieProjectDocChangeStatus = "unchanged"
+)
+
+type EllieKnownProjectDoc struct {
+	FilePath    string
+	ContentHash string
+}
+
+type EllieDiscoveredProjectDoc struct {
+	FilePath         string
+	Title            string
+	Content          string
+	ContentHash      string
+	Summary          string
+	SummaryEmbedding []float64
+	ChangeStatus     EllieProjectDocChangeStatus
+	StartHereLinked  bool
+}
+
+type EllieProjectDocsScanInput struct {
+	ProjectRoot string
+	KnownDocs   []EllieKnownProjectDoc
+}
+
+type EllieProjectDocsScanResult struct {
+	Documents    []EllieDiscoveredProjectDoc
+	DeletedPaths []string
+}
+
+type EllieProjectDocStoreRecord struct {
+	FilePath    string
+	ContentHash string
+}
+
+type EllieProjectDocStoreUpsertInput struct {
+	OrgID            string
+	ProjectID        string
+	FilePath         string
+	Title            string
+	Summary          string
+	SummaryEmbedding []float64
+	ContentHash      string
+}
+
+type EllieProjectDocsStore interface {
+	ListActiveProjectDocs(ctx context.Context, orgID, projectID string) ([]EllieProjectDocStoreRecord, error)
+	UpsertProjectDoc(ctx context.Context, input EllieProjectDocStoreUpsertInput) (string, error)
+	MarkProjectDocsInactiveExcept(ctx context.Context, orgID, projectID string, keepPaths []string) (int, error)
+}
+
+type EllieProjectDocsScanAndPersistInput struct {
+	OrgID       string
+	ProjectID   string
+	ProjectRoot string
+	Store       EllieProjectDocsStore
+}
+
+type EllieProjectDocsPersistResult struct {
+	ProcessedDocs   int
+	UpdatedDocs     int
+	InactivatedDocs int
+	DeletedPaths    []string
+}
+
+type EllieProjectDocSummarizer interface {
+	Summarize(ctx context.Context, input EllieProjectDocSummaryInput) (string, error)
+}
+
+type EllieProjectDocEmbeddingClient interface {
+	Embed(ctx context.Context, inputs []string) ([][]float64, error)
+}
+
+type EllieProjectDocSummaryInput struct {
+	FilePath     string
+	Title        string
+	Content      string
+	SectionIndex int
+	SectionTotal int
+}
+
+type EllieProjectDocsScanner struct {
+	Summarizer      EllieProjectDocSummarizer
+	EmbeddingClient EllieProjectDocEmbeddingClient
+	MaxSectionChars int
+}
+
+func (s *EllieProjectDocsScanner) Scan(
+	ctx context.Context,
+	input EllieProjectDocsScanInput,
+) (EllieProjectDocsScanResult, error) {
+	root := strings.TrimSpace(input.ProjectRoot)
+	if root == "" {
+		return EllieProjectDocsScanResult{}, fmt.Errorf("project root is required")
+	}
+	absRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return EllieProjectDocsScanResult{}, fmt.Errorf("resolve project root: %w", err)
+	}
+	docsRoot := filepath.Join(absRoot, "docs")
+
+	knownHashes := make(map[string]string, len(input.KnownDocs))
+	for _, knownDoc := range input.KnownDocs {
+		normalizedPath := normalizeProjectDocPath(knownDoc.FilePath)
+		if normalizedPath == "" {
+			continue
+		}
+		knownHashes[normalizedPath] = strings.TrimSpace(knownDoc.ContentHash)
+	}
+
+	if info, err := os.Stat(docsRoot); err != nil || !info.IsDir() {
+		deletedPaths := make([]string, 0, len(knownHashes))
+		for path := range knownHashes {
+			deletedPaths = append(deletedPaths, path)
+		}
+		sort.Strings(deletedPaths)
+		return EllieProjectDocsScanResult{DeletedPaths: deletedPaths}, nil
+	}
+
+	documents := make([]EllieDiscoveredProjectDoc, 0)
+	err = filepath.WalkDir(docsRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			return nil
+		}
+
+		contentBytes, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read project doc %q: %w", path, err)
+		}
+
+		relPath, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return fmt.Errorf("compute project doc relative path: %w", err)
+		}
+		normalizedPath := normalizeProjectDocPath(relPath)
+		content := string(contentBytes)
+		contentHash := md5HexString(contentBytes)
+		title := extractMarkdownTitle(normalizedPath, content)
+
+		changeStatus := EllieProjectDocChangeStatusNew
+		if existingHash, ok := knownHashes[normalizedPath]; ok {
+			if existingHash == contentHash {
+				changeStatus = EllieProjectDocChangeStatusUnchanged
+			} else {
+				changeStatus = EllieProjectDocChangeStatusChanged
+			}
+			delete(knownHashes, normalizedPath)
+		}
+
+		documents = append(documents, EllieDiscoveredProjectDoc{
+			FilePath:     normalizedPath,
+			Title:        title,
+			Content:      content,
+			ContentHash:  contentHash,
+			ChangeStatus: changeStatus,
+		})
+		return nil
+	})
+	if err != nil {
+		return EllieProjectDocsScanResult{}, err
+	}
+
+	sort.Slice(documents, func(i, j int) bool {
+		return documents[i].FilePath < documents[j].FilePath
+	})
+
+	startHereLinks := discoverStartHereLinkedDocs(absRoot, docsRoot, documents)
+	for i := range documents {
+		if _, ok := startHereLinks[documents[i].FilePath]; ok {
+			documents[i].StartHereLinked = true
+		}
+	}
+
+	deletedPaths := make([]string, 0, len(knownHashes))
+	for path := range knownHashes {
+		deletedPaths = append(deletedPaths, path)
+	}
+	sort.Strings(deletedPaths)
+
+	return EllieProjectDocsScanResult{
+		Documents:    documents,
+		DeletedPaths: deletedPaths,
+	}, nil
+}
+
+func (s *EllieProjectDocsScanner) SummarizeAndEmbedDocuments(
+	ctx context.Context,
+	documents []EllieDiscoveredProjectDoc,
+) ([]EllieDiscoveredProjectDoc, error) {
+	if len(documents) == 0 {
+		return []EllieDiscoveredProjectDoc{}, nil
+	}
+	if s == nil {
+		return nil, fmt.Errorf("project docs scanner is required")
+	}
+	if s.Summarizer == nil {
+		return nil, fmt.Errorf("project docs summarizer is required")
+	}
+	if s.EmbeddingClient == nil {
+		return nil, fmt.Errorf("project docs embedding client is required")
+	}
+
+	maxSectionChars := s.MaxSectionChars
+	if maxSectionChars <= 0 {
+		maxSectionChars = defaultProjectDocSectionMaxChars
+	}
+
+	enriched := make([]EllieDiscoveredProjectDoc, len(documents))
+	copy(enriched, documents)
+
+	for i := range enriched {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if enriched[i].ChangeStatus == EllieProjectDocChangeStatusUnchanged {
+			continue
+		}
+
+		sections := splitProjectDocIntoSections(enriched[i].Content, maxSectionChars)
+		sectionSummaries := make([]string, 0, len(sections))
+		for sectionIndex, section := range sections {
+			summary, err := s.Summarizer.Summarize(ctx, EllieProjectDocSummaryInput{
+				FilePath:     enriched[i].FilePath,
+				Title:        enriched[i].Title,
+				Content:      section,
+				SectionIndex: sectionIndex,
+				SectionTotal: len(sections),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("summarize %s section %d: %w", enriched[i].FilePath, sectionIndex+1, err)
+			}
+			summary = strings.TrimSpace(summary)
+			if summary != "" {
+				sectionSummaries = append(sectionSummaries, summary)
+			}
+		}
+
+		finalSummary := strings.TrimSpace(strings.Join(sectionSummaries, "\n\n"))
+		enriched[i].Summary = finalSummary
+		if finalSummary == "" {
+			enriched[i].SummaryEmbedding = nil
+			continue
+		}
+
+		embeddings, err := s.EmbeddingClient.Embed(ctx, []string{finalSummary})
+		if err != nil {
+			return nil, fmt.Errorf("embed summary for %s: %w", enriched[i].FilePath, err)
+		}
+		if len(embeddings) != 1 || len(embeddings[0]) == 0 {
+			return nil, fmt.Errorf("embed summary for %s: missing embedding", enriched[i].FilePath)
+		}
+		enriched[i].SummaryEmbedding = embeddings[0]
+	}
+
+	return enriched, nil
+}
+
+func (s *EllieProjectDocsScanner) ScanAndPersist(
+	ctx context.Context,
+	input EllieProjectDocsScanAndPersistInput,
+) (EllieProjectDocsPersistResult, error) {
+	if s == nil {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("project docs scanner is required")
+	}
+	if input.Store == nil {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("project docs store is required")
+	}
+
+	orgID := strings.TrimSpace(input.OrgID)
+	if orgID == "" {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("org_id is required")
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	if projectID == "" {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("project_id is required")
+	}
+
+	knownRecords, err := input.Store.ListActiveProjectDocs(ctx, orgID, projectID)
+	if err != nil {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("list active project docs: %w", err)
+	}
+	knownDocs := make([]EllieKnownProjectDoc, 0, len(knownRecords))
+	for _, record := range knownRecords {
+		knownDocs = append(knownDocs, EllieKnownProjectDoc{
+			FilePath:    record.FilePath,
+			ContentHash: record.ContentHash,
+		})
+	}
+
+	scanResult, err := s.Scan(ctx, EllieProjectDocsScanInput{
+		ProjectRoot: input.ProjectRoot,
+		KnownDocs:   knownDocs,
+	})
+	if err != nil {
+		return EllieProjectDocsPersistResult{}, err
+	}
+
+	docs := scanResult.Documents
+	if s.Summarizer != nil && s.EmbeddingClient != nil {
+		docs, err = s.SummarizeAndEmbedDocuments(ctx, docs)
+		if err != nil {
+			return EllieProjectDocsPersistResult{}, err
+		}
+	}
+
+	keepPaths := make([]string, 0, len(docs))
+	updatedDocs := 0
+	for _, doc := range docs {
+		keepPaths = append(keepPaths, doc.FilePath)
+		if doc.ChangeStatus == EllieProjectDocChangeStatusUnchanged {
+			continue
+		}
+		if _, err := input.Store.UpsertProjectDoc(ctx, EllieProjectDocStoreUpsertInput{
+			OrgID:            orgID,
+			ProjectID:        projectID,
+			FilePath:         doc.FilePath,
+			Title:            doc.Title,
+			Summary:          doc.Summary,
+			SummaryEmbedding: doc.SummaryEmbedding,
+			ContentHash:      doc.ContentHash,
+		}); err != nil {
+			return EllieProjectDocsPersistResult{}, fmt.Errorf("upsert project doc %s: %w", doc.FilePath, err)
+		}
+		updatedDocs += 1
+	}
+
+	inactivatedDocs, err := input.Store.MarkProjectDocsInactiveExcept(ctx, orgID, projectID, keepPaths)
+	if err != nil {
+		return EllieProjectDocsPersistResult{}, fmt.Errorf("mark project docs inactive: %w", err)
+	}
+
+	return EllieProjectDocsPersistResult{
+		ProcessedDocs:   len(docs),
+		UpdatedDocs:     updatedDocs,
+		InactivatedDocs: inactivatedDocs,
+		DeletedPaths:    append([]string(nil), scanResult.DeletedPaths...),
+	}, nil
+}
+
+func discoverStartHereLinkedDocs(
+	projectRoot string,
+	docsRoot string,
+	documents []EllieDiscoveredProjectDoc,
+) map[string]struct{} {
+	linked := make(map[string]struct{})
+	startHerePath := "docs/START-HERE.md"
+
+	var startHereContent string
+	for _, doc := range documents {
+		if doc.FilePath == startHerePath {
+			startHereContent = doc.Content
+			break
+		}
+	}
+	if startHereContent == "" {
+		return linked
+	}
+
+	baseDir := filepath.Join(projectRoot, "docs")
+	matches := markdownLinkPattern.FindAllStringSubmatch(startHereContent, -1)
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		target := strings.TrimSpace(match[1])
+		if target == "" || strings.HasPrefix(target, "#") {
+			continue
+		}
+		targetLower := strings.ToLower(target)
+		if strings.HasPrefix(targetLower, "http://") ||
+			strings.HasPrefix(targetLower, "https://") ||
+			strings.HasPrefix(targetLower, "mailto:") {
+			continue
+		}
+
+		if hash := strings.Index(target, "#"); hash >= 0 {
+			target = target[:hash]
+		}
+		if query := strings.Index(target, "?"); query >= 0 {
+			target = target[:query]
+		}
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+
+		var candidate string
+		if strings.HasPrefix(target, "/") {
+			candidate = filepath.Join(projectRoot, target)
+		} else {
+			candidate = filepath.Join(baseDir, target)
+		}
+		candidate = filepath.Clean(candidate)
+		relToDocs, err := filepath.Rel(docsRoot, candidate)
+		if err != nil {
+			continue
+		}
+		if relToDocs == ".." || strings.HasPrefix(relToDocs, ".."+string(os.PathSeparator)) {
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(candidate), ".md") {
+			continue
+		}
+
+		relToProject, err := filepath.Rel(projectRoot, candidate)
+		if err != nil {
+			continue
+		}
+		normalizedPath := normalizeProjectDocPath(relToProject)
+		if normalizedPath == "" || normalizedPath == startHerePath {
+			continue
+		}
+		linked[normalizedPath] = struct{}{}
+	}
+	return linked
+}
+
+func extractMarkdownTitle(filePath, content string) string {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		title := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+		if title != "" {
+			return title
+		}
+	}
+	base := filepath.Base(filePath)
+	ext := filepath.Ext(base)
+	return strings.TrimSuffix(base, ext)
+}
+
+func md5HexString(payload []byte) string {
+	sum := md5.Sum(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeProjectDocPath(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	cleaned := filepath.ToSlash(filepath.Clean(trimmed))
+	cleaned = strings.TrimPrefix(cleaned, "./")
+	if cleaned == "." || cleaned == "" {
+		return ""
+	}
+	return cleaned
+}
+
+func splitProjectDocIntoSections(content string, maxChars int) []string {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return []string{""}
+	}
+	if maxChars <= 0 || len(trimmed) <= maxChars {
+		return []string{trimmed}
+	}
+
+	paragraphs := strings.Split(trimmed, "\n\n")
+	sections := make([]string, 0, len(paragraphs))
+	current := strings.Builder{}
+
+	flush := func() {
+		section := strings.TrimSpace(current.String())
+		if section != "" {
+			sections = append(sections, section)
+		}
+		current.Reset()
+	}
+
+	for _, paragraph := range paragraphs {
+		chunk := strings.TrimSpace(paragraph)
+		if chunk == "" {
+			continue
+		}
+		if len(chunk) > maxChars {
+			if current.Len() > 0 {
+				flush()
+			}
+			for len(chunk) > maxChars {
+				sections = append(sections, strings.TrimSpace(chunk[:maxChars]))
+				chunk = strings.TrimSpace(chunk[maxChars:])
+			}
+			if chunk != "" {
+				sections = append(sections, chunk)
+			}
+			continue
+		}
+
+		next := chunk
+		if current.Len() > 0 {
+			next = current.String() + "\n\n" + chunk
+		}
+		if len(next) > maxChars && current.Len() > 0 {
+			flush()
+		}
+		if current.Len() > 0 {
+			current.WriteString("\n\n")
+		}
+		current.WriteString(chunk)
+	}
+	if current.Len() > 0 {
+		flush()
+	}
+	if len(sections) == 0 {
+		return []string{trimmed}
+	}
+	return sections
+}

--- a/internal/memory/ellie_project_docs_scanner_test.go
+++ b/internal/memory/ellie_project_docs_scanner_test.go
@@ -1,0 +1,304 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEllieProjectDocsScannerDiscoversMarkdownFiles(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs", "guides"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "overview.md"), []byte("# Overview\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "guides", "setup.md"), []byte("# Setup\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "notes.txt"), []byte("ignore"), 0o644))
+
+	scanner := &EllieProjectDocsScanner{}
+	result, err := scanner.Scan(context.Background(), EllieProjectDocsScanInput{
+		ProjectRoot: projectRoot,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Documents, 2)
+	require.Equal(t, "docs/guides/setup.md", result.Documents[0].FilePath)
+	require.Equal(t, EllieProjectDocChangeStatusNew, result.Documents[0].ChangeStatus)
+	require.Equal(t, "docs/overview.md", result.Documents[1].FilePath)
+	require.Equal(t, EllieProjectDocChangeStatusNew, result.Documents[1].ChangeStatus)
+}
+
+func TestEllieProjectDocsScannerParsesStartHereLinks(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs", "guides"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "overview.md"), []byte("# Overview\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "guides", "setup.md"), []byte("# Setup\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRoot, "docs", "START-HERE.md"),
+		[]byte("# Start Here\n- [Overview](./overview.md)\n- [Setup](guides/setup.md)\n- [External](https://example.com)\n"),
+		0o644,
+	))
+
+	scanner := &EllieProjectDocsScanner{}
+	result, err := scanner.Scan(context.Background(), EllieProjectDocsScanInput{
+		ProjectRoot: projectRoot,
+	})
+	require.NoError(t, err)
+
+	linked := map[string]bool{}
+	for _, doc := range result.Documents {
+		linked[doc.FilePath] = doc.StartHereLinked
+	}
+	require.True(t, linked["docs/overview.md"])
+	require.True(t, linked["docs/guides/setup.md"])
+	require.False(t, linked["docs/START-HERE.md"])
+}
+
+func TestEllieProjectDocsScannerDetectsChangedAndDeletedFiles(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "keep.md"), []byte("# Keep\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "changed.md"), []byte("# Changed v2\n"), 0o644))
+
+	keepHash := md5HexString([]byte("# Keep\n"))
+
+	scanner := &EllieProjectDocsScanner{}
+	result, err := scanner.Scan(context.Background(), EllieProjectDocsScanInput{
+		ProjectRoot: projectRoot,
+		KnownDocs: []EllieKnownProjectDoc{
+			{FilePath: "docs/keep.md", ContentHash: keepHash},
+			{FilePath: "docs/changed.md", ContentHash: "old-hash"},
+			{FilePath: "docs/deleted.md", ContentHash: "deleted-hash"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"docs/deleted.md"}, result.DeletedPaths)
+
+	statusByPath := map[string]EllieProjectDocChangeStatus{}
+	for _, doc := range result.Documents {
+		statusByPath[doc.FilePath] = doc.ChangeStatus
+	}
+	require.Equal(t, EllieProjectDocChangeStatusUnchanged, statusByPath["docs/keep.md"])
+	require.Equal(t, EllieProjectDocChangeStatusChanged, statusByPath["docs/changed.md"])
+}
+
+func TestEllieProjectDocsScannerSummarizesAndEmbedsChangedDocs(t *testing.T) {
+	summarizer := &fakeProjectDocSummarizer{}
+	embedder := &fakeProjectDocEmbedder{}
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      summarizer,
+		EmbeddingClient: embedder,
+		MaxSectionChars: 1024,
+	}
+
+	docs := []EllieDiscoveredProjectDoc{
+		{
+			FilePath:     "docs/changed.md",
+			Content:      "# Changed\nContent",
+			ChangeStatus: EllieProjectDocChangeStatusChanged,
+		},
+		{
+			FilePath:     "docs/new.md",
+			Content:      "# New\nContent",
+			ChangeStatus: EllieProjectDocChangeStatusNew,
+		},
+	}
+
+	enriched, err := scanner.SummarizeAndEmbedDocuments(context.Background(), docs)
+	require.NoError(t, err)
+	require.Len(t, enriched, 2)
+	require.Equal(t, "summary:docs/changed.md:1", enriched[0].Summary)
+	require.Len(t, enriched[0].SummaryEmbedding, 1536)
+	require.Equal(t, "summary:docs/new.md:1", enriched[1].Summary)
+	require.Len(t, enriched[1].SummaryEmbedding, 1536)
+	require.Len(t, summarizer.calls, 2)
+	require.Len(t, embedder.calls, 2)
+}
+
+func TestEllieProjectDocsScannerSkipsUnchangedDocs(t *testing.T) {
+	summarizer := &fakeProjectDocSummarizer{}
+	embedder := &fakeProjectDocEmbedder{}
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      summarizer,
+		EmbeddingClient: embedder,
+		MaxSectionChars: 1024,
+	}
+
+	docs := []EllieDiscoveredProjectDoc{
+		{
+			FilePath:     "docs/unchanged.md",
+			Content:      "# Unchanged\nNo-op",
+			ChangeStatus: EllieProjectDocChangeStatusUnchanged,
+		},
+	}
+
+	enriched, err := scanner.SummarizeAndEmbedDocuments(context.Background(), docs)
+	require.NoError(t, err)
+	require.Len(t, enriched, 1)
+	require.Empty(t, enriched[0].Summary)
+	require.Nil(t, enriched[0].SummaryEmbedding)
+	require.Empty(t, summarizer.calls)
+	require.Empty(t, embedder.calls)
+}
+
+func TestEllieProjectDocsScannerSplitsLargeDocsIntoSections(t *testing.T) {
+	summarizer := &fakeProjectDocSummarizer{}
+	embedder := &fakeProjectDocEmbedder{}
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      summarizer,
+		EmbeddingClient: embedder,
+		MaxSectionChars: 40,
+	}
+
+	docs := []EllieDiscoveredProjectDoc{
+		{
+			FilePath: "docs/large.md",
+			Content: strings.Join([]string{
+				"# Large",
+				"",
+				"Section one paragraph that exceeds the section limit.",
+				"",
+				"Section two paragraph also exceeds the section limit.",
+			}, "\n"),
+			ChangeStatus: EllieProjectDocChangeStatusChanged,
+		},
+	}
+
+	enriched, err := scanner.SummarizeAndEmbedDocuments(context.Background(), docs)
+	require.NoError(t, err)
+	require.Len(t, enriched, 1)
+	require.Greater(t, len(summarizer.calls), 1)
+	require.Len(t, embedder.calls, 1)
+	require.Contains(t, enriched[0].Summary, "summary:docs/large.md:1")
+	require.Contains(t, enriched[0].Summary, "summary:docs/large.md:2")
+}
+
+func TestEllieProjectDocsScannerRescanUpdatesAndInactivatesDocs(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "keep.md"), []byte("# Keep\nUpdated"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "new.md"), []byte("# New\nAdded"), 0o644))
+
+	fakeStore := &fakeProjectDocsStore{
+		activeDocs: map[string]fakeProjectDocRecord{
+			"docs/keep.md":  {contentHash: "old-hash", active: true},
+			"docs/stale.md": {contentHash: "stale-hash", active: true},
+		},
+	}
+
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      &fakeProjectDocSummarizer{},
+		EmbeddingClient: &fakeProjectDocEmbedder{},
+		MaxSectionChars: 1024,
+	}
+
+	result, err := scanner.ScanAndPersist(context.Background(), EllieProjectDocsScanAndPersistInput{
+		OrgID:       "org-1",
+		ProjectID:   "project-1",
+		ProjectRoot: projectRoot,
+		Store:       fakeStore,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.ProcessedDocs)
+	require.Equal(t, 2, result.UpdatedDocs)
+	require.Equal(t, 1, result.InactivatedDocs)
+	require.Equal(t, []string{"docs/stale.md"}, result.DeletedPaths)
+
+	require.True(t, fakeStore.activeDocs["docs/keep.md"].active)
+	require.True(t, fakeStore.activeDocs["docs/new.md"].active)
+	require.False(t, fakeStore.activeDocs["docs/stale.md"].active)
+	require.Len(t, fakeStore.upserts, 2)
+	require.NotEmpty(t, fakeStore.upserts[0].Summary)
+	require.Len(t, fakeStore.upserts[0].SummaryEmbedding, 1536)
+}
+
+type fakeProjectDocSummarizer struct {
+	calls []EllieProjectDocSummaryInput
+}
+
+func (f *fakeProjectDocSummarizer) Summarize(
+	_ context.Context,
+	input EllieProjectDocSummaryInput,
+) (string, error) {
+	f.calls = append(f.calls, input)
+	return "summary:" + input.FilePath + ":" + strconv.Itoa(input.SectionIndex+1), nil
+}
+
+type fakeProjectDocEmbedder struct {
+	calls [][]string
+}
+
+func (f *fakeProjectDocEmbedder) Embed(_ context.Context, inputs []string) ([][]float64, error) {
+	f.calls = append(f.calls, append([]string(nil), inputs...))
+	vector := make([]float64, 1536)
+	vector[0] = 1
+	return [][]float64{vector}, nil
+}
+
+type fakeProjectDocRecord struct {
+	contentHash string
+	active      bool
+}
+
+type fakeProjectDocsStore struct {
+	activeDocs map[string]fakeProjectDocRecord
+	upserts    []EllieProjectDocStoreUpsertInput
+}
+
+func (f *fakeProjectDocsStore) ListActiveProjectDocs(
+	_ context.Context,
+	_ string,
+	_ string,
+) ([]EllieProjectDocStoreRecord, error) {
+	rows := make([]EllieProjectDocStoreRecord, 0, len(f.activeDocs))
+	for path, row := range f.activeDocs {
+		if !row.active {
+			continue
+		}
+		rows = append(rows, EllieProjectDocStoreRecord{
+			FilePath:    path,
+			ContentHash: row.contentHash,
+		})
+	}
+	return rows, nil
+}
+
+func (f *fakeProjectDocsStore) UpsertProjectDoc(
+	_ context.Context,
+	input EllieProjectDocStoreUpsertInput,
+) (string, error) {
+	f.upserts = append(f.upserts, input)
+	f.activeDocs[input.FilePath] = fakeProjectDocRecord{
+		contentHash: input.ContentHash,
+		active:      true,
+	}
+	return "doc-id", nil
+}
+
+func (f *fakeProjectDocsStore) MarkProjectDocsInactiveExcept(
+	_ context.Context,
+	_ string,
+	_ string,
+	keepPaths []string,
+) (int, error) {
+	keep := make(map[string]struct{}, len(keepPaths))
+	for _, path := range keepPaths {
+		keep[path] = struct{}{}
+	}
+
+	inactivated := 0
+	for path, row := range f.activeDocs {
+		if !row.active {
+			continue
+		}
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		row.active = false
+		f.activeDocs[path] = row
+		inactivated++
+	}
+	return inactivated, nil
+}

--- a/internal/memory/project_docs_integration_test.go
+++ b/internal/memory/project_docs_integration_test.go
@@ -1,0 +1,322 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/samhotchkiss/otter-camp/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+type integrationProjectDocsStore struct {
+	mu sync.Mutex
+
+	repoRoot    string
+	docs        map[string]EllieProjectDocStoreUpsertInput
+	active      map[string]bool
+	roomResults []store.EllieRoomContextResult
+	roomCalls   int
+}
+
+func newIntegrationProjectDocsStore(repoRoot string) *integrationProjectDocsStore {
+	return &integrationProjectDocsStore{
+		repoRoot: repoRoot,
+		docs:     make(map[string]EllieProjectDocStoreUpsertInput),
+		active:   make(map[string]bool),
+	}
+}
+
+func (s *integrationProjectDocsStore) ListActiveProjectDocs(
+	_ context.Context,
+	_ string,
+	_ string,
+) ([]EllieProjectDocStoreRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows := make([]EllieProjectDocStoreRecord, 0, len(s.docs))
+	for filePath, doc := range s.docs {
+		if !s.active[filePath] {
+			continue
+		}
+		rows = append(rows, EllieProjectDocStoreRecord{
+			FilePath:    filePath,
+			ContentHash: doc.ContentHash,
+		})
+	}
+	return rows, nil
+}
+
+func (s *integrationProjectDocsStore) UpsertProjectDoc(
+	_ context.Context,
+	input EllieProjectDocStoreUpsertInput,
+) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docs[input.FilePath] = input
+	s.active[input.FilePath] = true
+	return input.FilePath, nil
+}
+
+func (s *integrationProjectDocsStore) MarkProjectDocsInactiveExcept(
+	_ context.Context,
+	_ string,
+	_ string,
+	keepPaths []string,
+) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	keep := make(map[string]struct{}, len(keepPaths))
+	for _, filePath := range keepPaths {
+		keep[filePath] = struct{}{}
+	}
+
+	count := 0
+	for filePath, isActive := range s.active {
+		if !isActive {
+			continue
+		}
+		if _, ok := keep[filePath]; ok {
+			continue
+		}
+		s.active[filePath] = false
+		count += 1
+	}
+	return count, nil
+}
+
+func (s *integrationProjectDocsStore) SearchProjectDocsByEmbedding(
+	_ context.Context,
+	_ string,
+	projectID string,
+	_ string,
+	_ []float64,
+	limit int,
+) ([]store.EllieProjectDocSearchResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	paths := make([]string, 0, len(s.docs))
+	for filePath := range s.docs {
+		if s.active[filePath] {
+			paths = append(paths, filePath)
+		}
+	}
+	sort.Strings(paths)
+
+	if limit > 0 && len(paths) > limit {
+		paths = paths[:limit]
+	}
+	results := make([]store.EllieProjectDocSearchResult, 0, len(paths))
+	for _, filePath := range paths {
+		doc := s.docs[filePath]
+		results = append(results, store.EllieProjectDocSearchResult{
+			DocID:         filePath,
+			ProjectID:     projectID,
+			FilePath:      filePath,
+			Title:         doc.Title,
+			Summary:       doc.Summary,
+			LocalRepoPath: s.repoRoot,
+			Similarity:    1,
+		})
+	}
+	return results, nil
+}
+
+func (s *integrationProjectDocsStore) SearchRoomContext(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ string,
+	_ int,
+) ([]store.EllieRoomContextResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.roomCalls += 1
+	out := make([]store.EllieRoomContextResult, len(s.roomResults))
+	copy(out, s.roomResults)
+	return out, nil
+}
+
+func (s *integrationProjectDocsStore) SearchMemoriesByProject(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ string,
+	_ int,
+) ([]store.EllieMemorySearchResult, error) {
+	return []store.EllieMemorySearchResult{}, nil
+}
+
+func (s *integrationProjectDocsStore) SearchMemoriesOrgWide(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ int,
+) ([]store.EllieMemorySearchResult, error) {
+	return []store.EllieMemorySearchResult{}, nil
+}
+
+func (s *integrationProjectDocsStore) SearchChatHistory(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ int,
+) ([]store.EllieChatHistoryResult, error) {
+	return []store.EllieChatHistoryResult{}, nil
+}
+
+func (s *integrationProjectDocsStore) SearchMemoriesByProjectWithEmbedding(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ string,
+	_ []float64,
+	_ int,
+) ([]store.EllieMemorySearchResult, error) {
+	return []store.EllieMemorySearchResult{}, nil
+}
+
+func (s *integrationProjectDocsStore) SearchMemoriesOrgWideWithEmbedding(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ []float64,
+	_ int,
+) ([]store.EllieMemorySearchResult, error) {
+	return []store.EllieMemorySearchResult{}, nil
+}
+
+func (s *integrationProjectDocsStore) SearchChatHistoryWithEmbedding(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ []float64,
+	_ int,
+) ([]store.EllieChatHistoryResult, error) {
+	return []store.EllieChatHistoryResult{}, nil
+}
+
+func TestProjectDocsIngestionIntegrationScanToRetrieve(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "guide.md"), []byte("# Guide\nCanonical project guidance"), 0o644))
+
+	docsStore := newIntegrationProjectDocsStore(projectRoot)
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      &fakeProjectDocSummarizer{},
+		EmbeddingClient: &fakeProjectDocEmbedder{},
+		MaxSectionChars: 1024,
+	}
+
+	persistResult, err := scanner.ScanAndPersist(context.Background(), EllieProjectDocsScanAndPersistInput{
+		OrgID:       "org-1",
+		ProjectID:   "project-1",
+		ProjectRoot: projectRoot,
+		Store:       docsStore,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, persistResult.ProcessedDocs)
+	require.Equal(t, 1, persistResult.UpdatedDocs)
+
+	service := NewEllieRetrievalCascadeService(docsStore, nil)
+	service.QueryEmbedder = &fakeEllieQueryEmbedder{vectors: [][]float64{{0.8, 0.2}}}
+
+	response, err := service.Retrieve(context.Background(), EllieRetrievalRequest{
+		OrgID:     "org-1",
+		ProjectID: "project-1",
+		Query:     "guide",
+		Limit:     5,
+	})
+	require.NoError(t, err)
+	require.False(t, response.NoInformation)
+	require.Equal(t, 1, response.TierUsed)
+	require.Len(t, response.Items, 1)
+	require.Equal(t, "project_doc", response.Items[0].Source)
+	require.Contains(t, response.Items[0].Snippet, "Canonical project guidance")
+}
+
+func TestProjectDocsRankingBeatsConversationMemories(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "architecture.md"), []byte("# Architecture\nAuthoritative architecture direction"), 0o644))
+
+	docsStore := newIntegrationProjectDocsStore(projectRoot)
+	docsStore.roomResults = []store.EllieRoomContextResult{
+		{
+			MessageID: "room-msg-1",
+			RoomID:    "room-1",
+			Body:      "Room-level memory snippet",
+		},
+	}
+
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      &fakeProjectDocSummarizer{},
+		EmbeddingClient: &fakeProjectDocEmbedder{},
+		MaxSectionChars: 1024,
+	}
+	_, err := scanner.ScanAndPersist(context.Background(), EllieProjectDocsScanAndPersistInput{
+		OrgID:       "org-1",
+		ProjectID:   "project-1",
+		ProjectRoot: projectRoot,
+		Store:       docsStore,
+	})
+	require.NoError(t, err)
+
+	service := NewEllieRetrievalCascadeService(docsStore, nil)
+	service.QueryEmbedder = &fakeEllieQueryEmbedder{vectors: [][]float64{{1, 0}}}
+
+	response, err := service.Retrieve(context.Background(), EllieRetrievalRequest{
+		OrgID:     "org-1",
+		ProjectID: "project-1",
+		RoomID:    "room-1",
+		Query:     "architecture",
+		Limit:     5,
+	})
+	require.NoError(t, err)
+	require.False(t, response.NoInformation)
+	require.Equal(t, 1, response.TierUsed)
+	require.Equal(t, "project_doc", response.Items[0].Source)
+	require.Contains(t, response.Items[0].Snippet, "Authoritative architecture direction")
+	require.Equal(t, 0, docsStore.roomCalls)
+}
+
+func TestProjectDocsLargeDocumentSectioningIntegration(t *testing.T) {
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "docs"), 0o755))
+	largeContent := strings.Join([]string{
+		"# Large",
+		"",
+		"Section one paragraph that should be split by scanner sectioning.",
+		"",
+		"Section two paragraph that should also be split by scanner sectioning.",
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "docs", "large.md"), []byte(largeContent), 0o644))
+
+	docsStore := newIntegrationProjectDocsStore(projectRoot)
+	scanner := &EllieProjectDocsScanner{
+		Summarizer:      &fakeProjectDocSummarizer{},
+		EmbeddingClient: &fakeProjectDocEmbedder{},
+		MaxSectionChars: 40,
+	}
+
+	persistResult, err := scanner.ScanAndPersist(context.Background(), EllieProjectDocsScanAndPersistInput{
+		OrgID:       "org-1",
+		ProjectID:   "project-1",
+		ProjectRoot: projectRoot,
+		Store:       docsStore,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, persistResult.UpdatedDocs)
+
+	largeDoc := docsStore.docs["docs/large.md"]
+	require.Contains(t, largeDoc.Summary, "summary:docs/large.md:1")
+	require.Contains(t, largeDoc.Summary, "summary:docs/large.md:2")
+	require.Len(t, largeDoc.SummaryEmbedding, 1536)
+}

--- a/internal/store/ellie_project_docs_store.go
+++ b/internal/store/ellie_project_docs_store.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+type EllieProjectDoc struct {
+	ID            string
+	OrgID         string
+	ProjectID     string
+	FilePath      string
+	Title         string
+	Summary       string
+	ContentHash   string
+	LastScannedAt *time.Time
+	DeletedAt     *time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type UpsertEllieProjectDocInput struct {
+	OrgID            string
+	ProjectID        string
+	FilePath         string
+	Title            string
+	Summary          string
+	SummaryEmbedding []float64
+	ContentHash      string
+}
+
+type EllieProjectDocsStore struct {
+	db *sql.DB
+}
+
+func NewEllieProjectDocsStore(db *sql.DB) *EllieProjectDocsStore {
+	return &EllieProjectDocsStore{db: db}
+}
+
+func (s *EllieProjectDocsStore) UpsertProjectDoc(ctx context.Context, input UpsertEllieProjectDocInput) (string, error) {
+	if s == nil || s.db == nil {
+		return "", fmt.Errorf("ellie project docs store is not configured")
+	}
+
+	orgID := strings.TrimSpace(input.OrgID)
+	if !uuidRegex.MatchString(orgID) {
+		return "", fmt.Errorf("invalid org_id")
+	}
+	projectID := strings.TrimSpace(input.ProjectID)
+	if !uuidRegex.MatchString(projectID) {
+		return "", fmt.Errorf("invalid project_id")
+	}
+	filePath := strings.TrimSpace(input.FilePath)
+	if filePath == "" {
+		return "", fmt.Errorf("file_path is required")
+	}
+	contentHash := strings.TrimSpace(input.ContentHash)
+	if contentHash == "" {
+		return "", fmt.Errorf("content_hash is required")
+	}
+
+	var (
+		embeddingLiteral interface{}
+		err              error
+	)
+	if len(input.SummaryEmbedding) > 0 {
+		if len(input.SummaryEmbedding) != openAIEmbeddingDimension {
+			return "", fmt.Errorf("summary embedding must have %d dimensions", openAIEmbeddingDimension)
+		}
+		embeddingLiteral, err = formatVectorLiteral(input.SummaryEmbedding)
+		if err != nil {
+			return "", fmt.Errorf("format summary embedding: %w", err)
+		}
+	}
+
+	title := nullableTrimmedString(input.Title)
+	summary := nullableTrimmedString(input.Summary)
+
+	var id string
+	err = s.db.QueryRowContext(
+		ctx,
+		`INSERT INTO ellie_project_docs (
+			org_id,
+			project_id,
+			file_path,
+			title,
+			summary,
+			summary_embedding,
+			content_hash,
+			last_scanned_at,
+			is_active,
+			deleted_at
+		) VALUES ($1, $2, $3, $4, $5, $6::vector, $7, NOW(), true, NULL)
+		ON CONFLICT (org_id, project_id, file_path) DO UPDATE
+		SET title = EXCLUDED.title,
+			summary = EXCLUDED.summary,
+			summary_embedding = EXCLUDED.summary_embedding,
+			content_hash = EXCLUDED.content_hash,
+			last_scanned_at = NOW(),
+			is_active = true,
+			deleted_at = NULL
+		RETURNING id`,
+		orgID,
+		projectID,
+		filePath,
+		title,
+		summary,
+		embeddingLiteral,
+		contentHash,
+	).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("upsert project doc: %w", err)
+	}
+
+	return id, nil
+}
+
+func (s *EllieProjectDocsStore) ListActiveProjectDocs(ctx context.Context, orgID, projectID string) ([]EllieProjectDoc, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("ellie project docs store is not configured")
+	}
+
+	orgID = strings.TrimSpace(orgID)
+	if !uuidRegex.MatchString(orgID) {
+		return nil, fmt.Errorf("invalid org_id")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if !uuidRegex.MatchString(projectID) {
+		return nil, fmt.Errorf("invalid project_id")
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT
+			id,
+			org_id,
+			project_id,
+			file_path,
+			COALESCE(title, ''),
+			COALESCE(summary, ''),
+			content_hash,
+			last_scanned_at,
+			deleted_at,
+			created_at,
+			updated_at
+		FROM ellie_project_docs
+		WHERE org_id = $1
+		  AND project_id = $2
+		  AND is_active = true
+		ORDER BY file_path ASC`,
+		orgID,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list active project docs: %w", err)
+	}
+	defer rows.Close()
+
+	docs := make([]EllieProjectDoc, 0)
+	for rows.Next() {
+		var (
+			doc           EllieProjectDoc
+			lastScannedAt sql.NullTime
+			deletedAt     sql.NullTime
+		)
+		if err := rows.Scan(
+			&doc.ID,
+			&doc.OrgID,
+			&doc.ProjectID,
+			&doc.FilePath,
+			&doc.Title,
+			&doc.Summary,
+			&doc.ContentHash,
+			&lastScannedAt,
+			&deletedAt,
+			&doc.CreatedAt,
+			&doc.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan active project doc: %w", err)
+		}
+		if lastScannedAt.Valid {
+			scanned := lastScannedAt.Time
+			doc.LastScannedAt = &scanned
+		}
+		if deletedAt.Valid {
+			deleted := deletedAt.Time
+			doc.DeletedAt = &deleted
+		}
+		docs = append(docs, doc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active project docs: %w", err)
+	}
+
+	return docs, nil
+}
+
+func (s *EllieProjectDocsStore) MarkProjectDocsInactiveExcept(
+	ctx context.Context,
+	orgID, projectID string,
+	keepPaths []string,
+) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("ellie project docs store is not configured")
+	}
+
+	orgID = strings.TrimSpace(orgID)
+	if !uuidRegex.MatchString(orgID) {
+		return 0, fmt.Errorf("invalid org_id")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if !uuidRegex.MatchString(projectID) {
+		return 0, fmt.Errorf("invalid project_id")
+	}
+
+	normalizedKeepPaths := make([]string, 0, len(keepPaths))
+	seen := make(map[string]struct{}, len(keepPaths))
+	for _, raw := range keepPaths {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalizedKeepPaths = append(normalizedKeepPaths, trimmed)
+	}
+
+	var (
+		result sql.Result
+		err    error
+	)
+	if len(normalizedKeepPaths) == 0 {
+		result, err = s.db.ExecContext(
+			ctx,
+			`UPDATE ellie_project_docs
+			 SET is_active = false,
+			     deleted_at = NOW()
+			 WHERE org_id = $1
+			   AND project_id = $2
+			   AND is_active = true`,
+			orgID,
+			projectID,
+		)
+	} else {
+		result, err = s.db.ExecContext(
+			ctx,
+			`UPDATE ellie_project_docs
+			 SET is_active = false,
+			     deleted_at = NOW()
+			 WHERE org_id = $1
+			   AND project_id = $2
+			   AND is_active = true
+			   AND NOT (file_path = ANY($3::text[]))`,
+			orgID,
+			projectID,
+			pq.Array(normalizedKeepPaths),
+		)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("mark project docs inactive: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read inactivated row count: %w", err)
+	}
+
+	return int(rowsAffected), nil
+}
+
+func nullableTrimmedString(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/internal/store/ellie_project_docs_store_test.go
+++ b/internal/store/ellie_project_docs_store_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ellieProjectDocsEmbeddingVector(values ...float64) []float64 {
+	vector := make([]float64, 1536)
+	for i, value := range values {
+		if i >= len(vector) {
+			break
+		}
+		vector[i] = value
+	}
+	return vector
+}
+
+func TestEllieProjectDocsStoreUpsertAndIsolation(t *testing.T) {
+	connStr := getTestDatabaseURL(t)
+	db := setupTestDatabase(t, connStr)
+
+	orgA := createTestOrganization(t, db, "ellie-project-docs-org-a")
+	orgB := createTestOrganization(t, db, "ellie-project-docs-org-b")
+	projectA := createTestProject(t, db, orgA, "Project Docs A")
+	projectB := createTestProject(t, db, orgB, "Project Docs B")
+
+	docsStore := NewEllieProjectDocsStore(db)
+	ctx := context.Background()
+
+	_, err := docsStore.UpsertProjectDoc(ctx, UpsertEllieProjectDocInput{
+		OrgID:            orgA,
+		ProjectID:        projectA,
+		FilePath:         "docs/overview.md",
+		Title:            "Overview",
+		Summary:          "Initial summary",
+		SummaryEmbedding: ellieProjectDocsEmbeddingVector(1, 0, 0),
+		ContentHash:      "hash-v1",
+	})
+	require.NoError(t, err)
+
+	_, err = docsStore.UpsertProjectDoc(ctx, UpsertEllieProjectDocInput{
+		OrgID:            orgA,
+		ProjectID:        projectA,
+		FilePath:         "docs/overview.md",
+		Title:            "Overview",
+		Summary:          "Updated summary",
+		SummaryEmbedding: ellieProjectDocsEmbeddingVector(0.5, 0.5, 0),
+		ContentHash:      "hash-v2",
+	})
+	require.NoError(t, err)
+
+	_, err = docsStore.UpsertProjectDoc(ctx, UpsertEllieProjectDocInput{
+		OrgID:            orgB,
+		ProjectID:        projectB,
+		FilePath:         "docs/overview.md",
+		Title:            "Overview B",
+		Summary:          "Org B summary",
+		SummaryEmbedding: ellieProjectDocsEmbeddingVector(0, 1, 0),
+		ContentHash:      "hash-b1",
+	})
+	require.NoError(t, err)
+
+	docsA, err := docsStore.ListActiveProjectDocs(ctx, orgA, projectA)
+	require.NoError(t, err)
+	require.Len(t, docsA, 1)
+	require.Equal(t, "docs/overview.md", docsA[0].FilePath)
+	require.Equal(t, "Updated summary", docsA[0].Summary)
+	require.Equal(t, "hash-v2", docsA[0].ContentHash)
+
+	docsB, err := docsStore.ListActiveProjectDocs(ctx, orgB, projectB)
+	require.NoError(t, err)
+	require.Len(t, docsB, 1)
+	require.Equal(t, "docs/overview.md", docsB[0].FilePath)
+	require.Equal(t, "Org B summary", docsB[0].Summary)
+	require.Equal(t, "hash-b1", docsB[0].ContentHash)
+
+	var rowCount int
+	err = db.QueryRow(
+		`SELECT COUNT(*)
+		 FROM ellie_project_docs
+		 WHERE org_id = $1
+		   AND project_id = $2
+		   AND file_path = 'docs/overview.md'`,
+		orgA,
+		projectA,
+	).Scan(&rowCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, rowCount, "upsert should not duplicate project docs rows")
+}
+
+func TestEllieProjectDocsStoreMarksInactiveOnDelete(t *testing.T) {
+	connStr := getTestDatabaseURL(t)
+	db := setupTestDatabase(t, connStr)
+
+	orgID := createTestOrganization(t, db, "ellie-project-docs-delete-org")
+	projectID := createTestProject(t, db, orgID, "Project Docs Delete")
+
+	docsStore := NewEllieProjectDocsStore(db)
+	ctx := context.Background()
+
+	_, err := docsStore.UpsertProjectDoc(ctx, UpsertEllieProjectDocInput{
+		OrgID:            orgID,
+		ProjectID:        projectID,
+		FilePath:         "docs/keep.md",
+		Title:            "Keep",
+		Summary:          "Keep summary",
+		SummaryEmbedding: ellieProjectDocsEmbeddingVector(1, 0, 0),
+		ContentHash:      "keep-hash",
+	})
+	require.NoError(t, err)
+	_, err = docsStore.UpsertProjectDoc(ctx, UpsertEllieProjectDocInput{
+		OrgID:            orgID,
+		ProjectID:        projectID,
+		FilePath:         "docs/delete.md",
+		Title:            "Delete",
+		Summary:          "Delete summary",
+		SummaryEmbedding: ellieProjectDocsEmbeddingVector(0, 1, 0),
+		ContentHash:      "delete-hash",
+	})
+	require.NoError(t, err)
+
+	inactivated, err := docsStore.MarkProjectDocsInactiveExcept(ctx, orgID, projectID, []string{"docs/keep.md"})
+	require.NoError(t, err)
+	require.Equal(t, 1, inactivated)
+
+	docs, err := docsStore.ListActiveProjectDocs(ctx, orgID, projectID)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "docs/keep.md", docs[0].FilePath)
+
+	var (
+		isActive  bool
+		deletedAt sql.NullTime
+	)
+	err = db.QueryRow(
+		`SELECT is_active, deleted_at
+		 FROM ellie_project_docs
+		 WHERE org_id = $1
+		   AND project_id = $2
+		   AND file_path = 'docs/delete.md'`,
+		orgID,
+		projectID,
+	).Scan(&isActive, &deletedAt)
+	require.NoError(t, err)
+	require.False(t, isActive)
+	require.True(t, deletedAt.Valid)
+}

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -298,34 +298,6 @@ func TestMigration063ConversationSchemaFilesExistAndContainCoreDDL(t *testing.T)
 	require.Contains(t, downContent, "drop table if exists memories")
 }
 
-func TestMigration080TaxonomySchemaFilesExistAndContainCoreDDL(t *testing.T) {
-	migrationsDir := getMigrationsDir(t)
-	files := []string{
-		"080_create_ellie_taxonomy_tables.up.sql",
-		"080_create_ellie_taxonomy_tables.down.sql",
-	}
-	for _, filename := range files {
-		_, err := os.Stat(filepath.Join(migrationsDir, filename))
-		require.NoError(t, err)
-	}
-
-	upRaw, err := os.ReadFile(filepath.Join(migrationsDir, "080_create_ellie_taxonomy_tables.up.sql"))
-	require.NoError(t, err)
-	upContent := strings.ToLower(string(upRaw))
-	require.Contains(t, upContent, "create table if not exists ellie_taxonomy_nodes")
-	require.Contains(t, upContent, "create table if not exists ellie_memory_taxonomy")
-	require.Contains(t, upContent, "unique (org_id, parent_id, slug)")
-	require.Contains(t, upContent, "primary key (memory_id, node_id)")
-	require.Contains(t, upContent, "enable row level security")
-	require.Contains(t, upContent, "ellie_taxonomy_nodes_org_isolation")
-
-	downRaw, err := os.ReadFile(filepath.Join(migrationsDir, "080_create_ellie_taxonomy_tables.down.sql"))
-	require.NoError(t, err)
-	downContent := strings.ToLower(string(downRaw))
-	require.Contains(t, downContent, "drop table if exists ellie_memory_taxonomy")
-	require.Contains(t, downContent, "drop table if exists ellie_taxonomy_nodes")
-}
-
 func TestSchemaConversationCoreTablesCreateAndRollback(t *testing.T) {
 	connStr := getTestDatabaseURL(t)
 	db, err := sql.Open("postgres", connStr)
@@ -745,6 +717,38 @@ func TestMigration078Embedding1536ColumnsFilesExistAndContainCoreDDL(t *testing.
 	require.Contains(t, downContent, "drop index if exists memories_embedding_1536_idx")
 	require.Contains(t, downContent, "drop index if exists chat_messages_embedding_1536_idx")
 	require.Contains(t, downContent, "drop column if exists embedding_1536")
+}
+
+func TestSchemaIncludesEllieProjectDocsMigration(t *testing.T) {
+	migrationsDir := getMigrationsDir(t)
+	files := []string{
+		"081_create_ellie_project_docs.up.sql",
+		"081_create_ellie_project_docs.down.sql",
+	}
+	for _, filename := range files {
+		_, err := os.Stat(filepath.Join(migrationsDir, filename))
+		require.NoError(t, err)
+	}
+
+	upRaw, err := os.ReadFile(filepath.Join(migrationsDir, "081_create_ellie_project_docs.up.sql"))
+	require.NoError(t, err)
+	upContent := strings.ToLower(string(upRaw))
+	require.Contains(t, upContent, "create table if not exists ellie_project_docs")
+	require.Contains(t, upContent, "summary_embedding vector(1536)")
+	require.Contains(t, upContent, "unique (org_id, project_id, file_path)")
+	require.Contains(t, upContent, "create index if not exists ellie_project_docs_org_project_active_idx")
+	require.Contains(t, upContent, "create index if not exists ellie_project_docs_embedding_idx")
+	require.Contains(t, upContent, "create trigger ellie_project_docs_updated_at_trg")
+	require.Contains(t, upContent, "create policy ellie_project_docs_org_isolation")
+
+	downRaw, err := os.ReadFile(filepath.Join(migrationsDir, "081_create_ellie_project_docs.down.sql"))
+	require.NoError(t, err)
+	downContent := strings.ToLower(string(downRaw))
+	require.Contains(t, downContent, "drop trigger if exists ellie_project_docs_updated_at_trg")
+	require.Contains(t, downContent, "drop index if exists ellie_project_docs_embedding_idx")
+	require.Contains(t, downContent, "drop index if exists ellie_project_docs_org_project_active_idx")
+	require.Contains(t, downContent, "drop policy if exists ellie_project_docs_org_isolation on ellie_project_docs")
+	require.Contains(t, downContent, "drop table if exists ellie_project_docs")
 }
 
 func TestSchemaConversationsSensitivityColumnAndConstraint(t *testing.T) {

--- a/migrations/081_create_ellie_project_docs.down.sql
+++ b/migrations/081_create_ellie_project_docs.down.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER IF EXISTS ellie_project_docs_updated_at_trg ON ellie_project_docs;
+DROP INDEX IF EXISTS ellie_project_docs_embedding_idx;
+DROP INDEX IF EXISTS ellie_project_docs_hash_idx;
+DROP INDEX IF EXISTS ellie_project_docs_org_project_active_idx;
+DROP POLICY IF EXISTS ellie_project_docs_org_isolation ON ellie_project_docs;
+DROP TABLE IF EXISTS ellie_project_docs;

--- a/migrations/081_create_ellie_project_docs.up.sql
+++ b/migrations/081_create_ellie_project_docs.up.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS ellie_project_docs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    file_path TEXT NOT NULL,
+    title TEXT,
+    summary TEXT,
+    summary_embedding vector(1536),
+    content_hash TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    last_scanned_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (org_id, project_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS ellie_project_docs_org_project_active_idx
+    ON ellie_project_docs (org_id, project_id, is_active, file_path);
+
+CREATE INDEX IF NOT EXISTS ellie_project_docs_hash_idx
+    ON ellie_project_docs (org_id, project_id, content_hash);
+
+CREATE INDEX IF NOT EXISTS ellie_project_docs_embedding_idx
+    ON ellie_project_docs USING ivfflat (summary_embedding vector_cosine_ops) WITH (lists = 100)
+    WHERE summary_embedding IS NOT NULL AND is_active = true;
+
+CREATE TRIGGER ellie_project_docs_updated_at_trg
+BEFORE UPDATE ON ellie_project_docs
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE ellie_project_docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ellie_project_docs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS ellie_project_docs_org_isolation ON ellie_project_docs;
+CREATE POLICY ellie_project_docs_org_isolation ON ellie_project_docs
+    USING (org_id = current_org_id())
+    WITH CHECK (org_id = current_org_id());


### PR DESCRIPTION
Project document discovery, summarization, embedding, and retrieval cascade integration.

- Schema: ellie_project_docs with 1536d embeddings, content hashing, IVFFlat index
- Scanner discovers markdown files in project repos
- LLM summarization + embedding pipeline
- Retrieval cascade: project docs searched first (tier 1) when project context available
- Migration phase 8 in runner (after taxonomy classification)
- Migration 081

Closes #304