### PR TITLE
Fix inbox landing route and live sidebar data

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -67,7 +67,7 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Dashboard />,
+        element: <Navigate to="/inbox" replace />,
       },
       {
         path: "tasks",


### PR DESCRIPTION
Summary:\n- Route root path to /inbox so landing content matches shell label.\n- Replace hardcoded sidebar inbox/projects with live API-backed adapter data.\n- Add empty-state fallbacks when APIs return no data.\n\nValidation:\n- cd web && npx vitest run src/layouts/DashboardLayout.test.tsx src/router.test.tsx\n- cd web && npm run build