### PR TITLE
Spec 524: Reduce bridge reminder context injection bloat

### DIFF
--- a/bridge/openclaw-bridge.test.ts
+++ b/bridge/openclaw-bridge.test.ts
@@ -535,8 +535,7 @@ describe("bridge identity preamble helpers", () => {
   const originalFetch = globalThis.fetch;
   const agentID = "a1b2c3d4-5678-90ab-cdef-1234567890ab";
   const sessionKey = `agent:chameleon:oc:${agentID}`;
-  const reminderGuidePointer =
-    "Refer to OTTERCAMP.md and OTTER_COMMANDS.md for CLI syntax and operating rules.";
+  const reminderGuidePointer = "Refer to OTTERCAMP.md and OTTER_COMMANDS.md for rules.";
 
   beforeEach(() => {
     resetSessionContextsForTest();
@@ -770,6 +769,23 @@ describe("bridge identity preamble helpers", () => {
       }
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("keeps UUID-only issue reminder payloads under 200 characters", async () => {
+    const issueSessionKey = "agent:main:issue:compact-reminder";
+    setSessionContextForTest(issueSessionKey, {
+      kind: "issue_comment",
+      projectID: "12345678-1234-1234-1234-123456789abc",
+      issueID: "87654321-4321-4321-4321-cba987654321",
+      orgID: "org-1",
+    });
+
+    await formatSessionSystemPromptForTest(issueSessionKey, "bootstrap turn");
+    const reminderPrompt = await formatSessionSystemPromptForTest(issueSessionKey, "next turn");
+
+    assert.ok(reminderPrompt.includes("[OTTERCAMP_CONTEXT_REMINDER]"));
+    assert.ok(reminderPrompt.includes(reminderGuidePointer));
+    assert.equal(reminderPrompt.length < 200, true);
   });
 
   it("syncs otter CLI auth config into the chameleon workspace home paths", () => {

--- a/bridge/openclaw-bridge.ts
+++ b/bridge/openclaw-bridge.ts
@@ -2825,7 +2825,7 @@ function buildContextReminder(context: SessionContext): string {
       typeof context.issueNumber === 'number' && Number.isFinite(context.issueNumber)
         ? `#${context.issueNumber}`
         : context.issueID || 'unknown issue';
-    return `Issue thread ${issueLabel} (${context.projectID || 'unknown project'})`;
+    return `Issue ${issueLabel} (${context.projectID || 'unknown project'})`;
   }
   return `DM thread (${context.threadID || 'unknown thread'})`;
 }
@@ -3538,7 +3538,7 @@ async function withSessionContext(
   }
   const reminder = [
     '[OTTERCAMP_CONTEXT_REMINDER]',
-    `- ${buildContextReminder(context)} | Refer to ${OTTERCAMP_WORKSPACE_GUIDE_FILENAME} and ${OTTERCAMP_COMMAND_REFERENCE_FILENAME} for CLI syntax and operating rules.`,
+    `- ${buildContextReminder(context)} | Refer to ${OTTERCAMP_WORKSPACE_GUIDE_FILENAME} and ${OTTERCAMP_COMMAND_REFERENCE_FILENAME} for rules.`,
     '[/OTTERCAMP_CONTEXT_REMINDER]',
   ].join('\n');
   if (!includeUserContent) {


### PR DESCRIPTION
## Summary
- minimize `withSessionContext()` post-bootstrap reminders to a single `OTTERCAMP_CONTEXT_REMINDER` block plus workspace file pointers
- remove reminder-path identity/guide/action-default re-injection while keeping bootstrap behavior intact
- add a regression test to enforce UUID-only issue reminder payloads stay under 200 chars

## Linked Issues
- Closes #1291
- Closes #1292

## Testing
- `npx tsx --test bridge/openclaw-bridge.test.ts --test-name-pattern "system prompt envelope|installs and injects the OtterCamp guide|injects the OtterCamp guide for elephant"`
- `npx tsx --test bridge/openclaw-bridge.test.ts --test-name-pattern "system prompt envelope|installs and injects the OtterCamp guide|injects the OtterCamp guide for elephant|keeps UUID-only issue reminder payloads"`
- `npm run test:bridge`
