### PR TITLE
Spec 531: Maintain bottom pin when chat footer/composer resizes

### DIFF
--- a/web/src/components/messaging/MessageHistory.tsx
+++ b/web/src/components/messaging/MessageHistory.tsx
@@ -460,6 +460,23 @@ export default function MessageHistory({
 
   useEffect(() => {
     const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!pinnedToBottomRef.current) {
+        return;
+      }
+      endRef.current?.scrollIntoView({ behavior: "auto" });
+    });
+    observer.observe(container);
+    return () => {
+      observer.disconnect();
+    };
+  }, [threadId]);
+
+  useEffect(() => {
+    const container = containerRef.current;
     if (!container) return;
 
     if (pendingPrependRef.current) {

--- a/web/src/components/messaging/__tests__/MessageHistory.test.tsx
+++ b/web/src/components/messaging/__tests__/MessageHistory.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MessageHistory from "../MessageHistory";
 import type { Agent, DMMessage } from "../types";
@@ -203,5 +203,115 @@ describe("MessageHistory", () => {
     expect(screen.getByText("Jeff G")).toBeInTheDocument();
     expect(screen.queryByText("avatar-design")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Jeff G")).toHaveTextContent("JG");
+  });
+
+  it("keeps scroll pinned to bottom on history resize when user is pinned", () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    const scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const resizeCallbacks: ResizeObserverCallback[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    class ResizeObserverMock {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback);
+      }
+    }
+    // @ts-expect-error test shim
+    globalThis.ResizeObserver = ResizeObserverMock;
+
+    const messages: DMMessage[] = [
+      {
+        id: "m1",
+        threadId: "dm_agent-1",
+        senderId: "user-1",
+        senderName: "You",
+        senderType: "user",
+        content: "Pinned",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      },
+    ];
+
+    const { container } = render(
+      <MessageHistory messages={messages} currentUserId="user-1" agent={agent} />,
+    );
+    const history = container.querySelector(".oc-chat-history") as HTMLDivElement;
+    Object.defineProperty(history, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(history, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(history, "scrollTop", { configurable: true, value: 500, writable: true });
+    fireEvent.scroll(history);
+
+    const baselineCalls = scrollIntoViewMock.mock.calls.length;
+    act(() => {
+      resizeCallbacks[0]?.([], {} as ResizeObserver);
+    });
+    expect(scrollIntoViewMock.mock.calls.length).toBeGreaterThan(baselineCalls);
+
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver;
+    } else {
+      // @ts-expect-error test shim
+      delete globalThis.ResizeObserver;
+    }
+    window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it("does not force scroll-to-bottom on history resize when user scrolled up", () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    const scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const resizeCallbacks: ResizeObserverCallback[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    class ResizeObserverMock {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback);
+      }
+    }
+    // @ts-expect-error test shim
+    globalThis.ResizeObserver = ResizeObserverMock;
+
+    const messages: DMMessage[] = [
+      {
+        id: "m1",
+        threadId: "dm_agent-1",
+        senderId: "user-1",
+        senderName: "You",
+        senderType: "user",
+        content: "Unpinned",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      },
+    ];
+
+    const { container } = render(
+      <MessageHistory messages={messages} currentUserId="user-1" agent={agent} />,
+    );
+    const history = container.querySelector(".oc-chat-history") as HTMLDivElement;
+    Object.defineProperty(history, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(history, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(history, "scrollTop", { configurable: true, value: 100, writable: true });
+    fireEvent.scroll(history);
+
+    const baselineCalls = scrollIntoViewMock.mock.calls.length;
+    act(() => {
+      resizeCallbacks[0]?.([], {} as ResizeObserver);
+    });
+    expect(scrollIntoViewMock.mock.calls.length).toBe(baselineCalls);
+
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver;
+    } else {
+      // @ts-expect-error test shim
+      delete globalThis.ResizeObserver;
+    }
+    window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 });


### PR DESCRIPTION
## Summary
- add resize-observer handling in `MessageHistory` to keep chat pinned to bottom when the history container resizes
- only auto-scroll on resize when the user is currently pinned (within existing bottom threshold)
- preserve manual scroll-up behavior by not forcing bottom pin when user is unpinned
- add regression tests for pinned and unpinned resize scenarios

## Testing
- `cd web && npm test -- --run src/components/messaging/__tests__/MessageHistory.test.tsx`
- `cd web && npm test -- --run src/components/chat/GlobalChatSurface.test.tsx`

## Issues
- Closes #1331
